### PR TITLE
docs: fix docs build command — change 'docs-v2' to 'docs'

### DIFF
--- a/docs/content/docs/contributing/testing.mdx
+++ b/docs/content/docs/contributing/testing.mdx
@@ -93,7 +93,7 @@ python -m pytest tests/test_runner_execution_contracts.py -q
 For docs changes:
 
 ```bash
-cd docs-v2
+cd docs
 npm run build
 ```
 


### PR DESCRIPTION
## Summary

The **Docs Checks** section in `docs/content/docs/contributing/testing.mdx` tells contributors to run:

```bash
cd docs-v2
npm run build
```

But there is no `docs-v2` directory in the repository. The correct directory is `docs/`. This PR fixes the command to:

```bash
cd docs
npm run build
```

## Why this matters

New contributors following the testing guide to verify doc changes would hit a `cd: no such file or directory: docs-v2` error immediately, making it look like their environment is broken when the guide itself is wrong.

## Test plan

- [ ] Verify `docs/` exists at the repository root (it does)
- [ ] Verify `docs/package.json` contains a `build` script (it does)
- [ ] Confirm no `docs-v2` directory exists anywhere in the repository