### PR TITLE
Add benchmark asset URL audit utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ task_generation_runs/
 task_result.json
 .vscode
 gemini_error_dumps/
+gym_anything_asset_audit

--- a/extras/utilities/__init__.py
+++ b/extras/utilities/__init__.py
@@ -1,0 +1,2 @@
+"""Utility methods for the gym-anything-extras dispatcher."""
+

--- a/extras/utilities/benchmark_assets/__init__.py
+++ b/extras/utilities/benchmark_assets/__init__.py
@@ -1,0 +1,2 @@
+"""Benchmark asset inspection utilities."""
+

--- a/extras/utilities/benchmark_assets/download_check/README.md
+++ b/extras/utilities/benchmark_assets/download_check/README.md
@@ -1,0 +1,36 @@
+# Benchmark Asset Download Check
+
+Scans CUA-World setup scripts for external asset URLs and optionally checks
+or downloads them.
+
+This method is adapted from the script shared by Tianbao Xie
+(`@Timothyxxx`) in
+<https://github.com/cmu-l3/gym-anything/issues/2>.
+
+## Usage
+
+```bash
+gym-anything-extras utilities benchmark_assets download_check
+```
+
+By default this only parses scripts and writes:
+
+```text
+gym_anything_asset_audit/asset_download_check.json
+```
+
+To probe link health without downloading full assets:
+
+```bash
+gym-anything-extras utilities benchmark_assets download_check --check-links --jobs 16
+```
+
+To reproduce the heavier download-style audit:
+
+```bash
+gym-anything-extras utilities benchmark_assets download_check --download --jobs 4
+```
+
+Use `--all-domains` to include URLs outside the known asset-domain allowlist.
+Use `--fail-on-dead` when running in automation.
+

--- a/extras/utilities/benchmark_assets/download_check/__init__.py
+++ b/extras/utilities/benchmark_assets/download_check/__init__.py
@@ -1,0 +1,2 @@
+"""Download/link health checker for benchmark setup assets."""
+

--- a/extras/utilities/benchmark_assets/download_check/method.py
+++ b/extras/utilities/benchmark_assets/download_check/method.py
@@ -1,0 +1,606 @@
+"""Scan and optionally check external benchmark asset URLs.
+
+Adapted for `gym-anything-extras` from the asset download/check script
+shared by Tianbao Xie (GitHub: @Timothyxxx) in cmu-l3/gym-anything
+issue #2:
+
+    https://github.com/cmu-l3/gym-anything/issues/2
+
+This utility is intentionally an extras method, not runtime code. It reads
+benchmark setup scripts, reports external asset dependencies, and can either
+probe links or download them into a local cache for investigation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from urllib.parse import unquote, urlparse
+
+
+DEFAULT_SKIP_PATTERNS = (
+    "localhost",
+    "127.0.0.1",
+    "0.0.0.0",
+    "${",
+    "$(",
+    "svc.cluster.local",
+    "/api/",
+    "/xmlrpc/",
+    "/web/login",
+    "/login",
+    "/health",
+    "/flush",
+    "/index.php",
+    "/interface/",
+)
+
+
+DEFAULT_ALLOWED_DOMAINS = {
+    # Media / images
+    "upload.wikimedia.org",
+    "images.metmuseum.org",
+    "esahubble.org",
+    "dl.polyhaven.org",
+    "imagej.nih.gov",
+    "wsr.imagej.net",
+    "imagej.net",
+    # Data / science
+    "files.rcsb.org",
+    "eutils.ncbi.nlm.nih.gov",
+    "archive.ics.uci.edu",
+    "data.broadinstitute.org",
+    "naciscdn.org",
+    "data.celltrackingchallenge.net",
+    "earthquake.usgs.gov",
+    "gml.noaa.gov",
+    "www.ncei.noaa.gov",
+    "data.usaid.gov",
+    "fred.stlouisfed.org",
+    "feodotracker.abuse.ch",
+    "www.cisa.gov",
+    "physionet.org",
+    "zenodo.org",
+    "ndownloader.figshare.com",
+    # Code / tools
+    "raw.githubusercontent.com",
+    "github.com",
+    "repo1.maven.org",
+    "services.gradle.org",
+    # GIS / maps
+    "www.naturalearthdata.com",
+    "naturalearth.s3.amazonaws.com",
+    "download.geofabrik.de",
+    "tile.loc.gov",
+    # 3D / assets
+    "download.blender.org",
+    # Books
+    "www.gutenberg.org",
+    # Video / audio
+    "commondatastorage.googleapis.com",
+    "actions.google.com",
+    # Science tools
+    "www.astro.louisville.edu",
+    "m-selig.ae.illinois.edu",
+    "energyplus-weather.s3.amazonaws.com",
+    "wiki.wireshark.org",
+    # Misc
+    "en.wikipedia.org",
+    "web.archive.org",
+    "huggingface.co",
+    "cdn.huggingface.co",
+    "www.rubomedical.com",
+    "downloads.mysql.com",
+    "download.oracle.com",
+    "download.eclipse.org",
+    "ftp.ebi.ac.uk",
+    "ftp.ncbi.nlm.nih.gov",
+    "stacks.iop.org",
+    "www.sample-videos.com",
+    "filesamples.com",
+    "file-examples.com",
+}
+
+
+@dataclass
+class UrlSource:
+    source_file: str
+    line: int
+    output_name: Optional[str] = None
+
+
+@dataclass
+class AssetEntry:
+    url: str
+    domain: Optional[str]
+    filename: str
+    used_by: list[str] = field(default_factory=list)
+    sources: list[UrlSource] = field(default_factory=list)
+    local_path: Optional[str] = None
+    status: Optional[str] = None
+    http_code: Optional[int] = None
+    size_bytes: Optional[int] = None
+    error: Optional[str] = None
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "src" / "gym_anything").is_dir() and (parent / "benchmarks").is_dir():
+            return parent
+    return Path.cwd()
+
+
+def _default_benchmarks_root() -> Path:
+    return _repo_root() / "benchmarks" / "cua_world" / "environments"
+
+
+def _default_output_dir() -> Path:
+    return _repo_root() / "gym_anything_asset_audit"
+
+
+def extract_urls_from_file(script_path: Path) -> list[tuple[str, int, Optional[str]]]:
+    """Extract download-looking URLs from one script.
+
+    The patterns intentionally match the issue author's script: shell
+    `wget`/`curl`, Python `urllib`/`requests`, and URL variable assignment.
+    """
+    try:
+        content = script_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    results: list[tuple[str, int, Optional[str]]] = []
+    for line_num, line in enumerate(content.splitlines(), 1):
+        urls: list[str] = []
+        output_name: Optional[str] = None
+
+        if "wget" in line or (
+            "curl" in line and ("-o" in line.lower() or "--output" in line)
+        ):
+            urls = re.findall(r"https?://[^\s\"'\\)}>]+", line)
+            match = re.search(r"-[oO]\s+[\"']?([^\s\"']+)", line)
+            if match:
+                output_name = match.group(1)
+            if not output_name:
+                match = re.search(r">\s*[\"']?([^\s\"']+)", line)
+                if match:
+                    output_name = match.group(1)
+        elif any(keyword in line for keyword in ("urlretrieve", "urlopen", "requests.get")):
+            urls = re.findall(r"https?://[^\s\"'\\)}>]+", line)
+        elif re.search(
+            r"(?:url|URL|download_url|DATA_URL|DOWNLOAD_URL|FILE_URL|SRC_URL)\s*=\s*[\"']https?://",
+            line,
+        ):
+            urls = re.findall(r"https?://[^\s\"'\\)}>]+", line)
+
+        for url in urls:
+            results.append((url.rstrip(",;"), line_num, output_name))
+    return results
+
+
+def should_skip(url: str, skip_patterns: Iterable[str] = DEFAULT_SKIP_PATTERNS) -> bool:
+    return any(pattern in url for pattern in skip_patterns)
+
+
+def is_allowed_domain(url: str, allowed_domains: set[str]) -> bool:
+    if not allowed_domains:
+        return True
+    return urlparse(url).hostname in allowed_domains
+
+
+def scan_assets(
+    benchmarks_root: Path,
+    *,
+    all_domains: bool = False,
+    include_env_scripts: bool = True,
+) -> tuple[list[AssetEntry], list[dict[str, Optional[str]]]]:
+    """Scan benchmark setup scripts and return unique URL entries."""
+    allowed_domains = set() if all_domains else DEFAULT_ALLOWED_DOMAINS
+    entries_by_url: dict[str, AssetEntry] = {}
+    filtered: list[dict[str, Optional[str]]] = []
+
+    def add_entry(script: Path, used_by: str) -> None:
+        for url, line, output_name in extract_urls_from_file(script):
+            if should_skip(url):
+                continue
+            domain = urlparse(url).hostname
+            if not is_allowed_domain(url, allowed_domains):
+                filtered.append({"url": url, "domain": domain})
+                continue
+            parsed = urlparse(url)
+            filename = unquote(Path(parsed.path).name) or "index.html"
+            entry = entries_by_url.get(url)
+            if entry is None:
+                entry = AssetEntry(url=url, domain=domain, filename=filename)
+                entries_by_url[url] = entry
+            if used_by not in entry.used_by:
+                entry.used_by.append(used_by)
+            entry.sources.append(
+                UrlSource(
+                    source_file=str(script),
+                    line=line,
+                    output_name=output_name,
+                )
+            )
+
+    for script in sorted(benchmarks_root.glob("*/tasks/*/setup_task.sh")):
+        parts = script.relative_to(benchmarks_root).parts
+        add_entry(script, f"{parts[0]}/{parts[2]}")
+
+    if include_env_scripts:
+        for script in sorted(benchmarks_root.glob("*/scripts/*.sh")):
+            env_name = script.relative_to(benchmarks_root).parts[0]
+            add_entry(script, f"{env_name}/_env_scripts")
+
+    return list(entries_by_url.values()), filtered
+
+
+def url_to_local_path(entry: AssetEntry, output_dir: Path) -> Path:
+    domain = entry.domain or "unknown"
+    filename = re.sub(r"[?#].*$", "", entry.filename)
+    filename = re.sub(r"[^\w.\-]", "_", filename)
+    if not filename or filename == "index.html":
+        filename = hashlib.md5(entry.url.encode()).hexdigest()[:12]
+    url_hash = hashlib.md5(entry.url.encode()).hexdigest()[:8]
+    safe_name = f"{url_hash}_{filename}"
+    if len(safe_name) > 200:
+        ext = Path(filename).suffix
+        safe_name = f"{url_hash}_{filename[:100]}{ext}"
+    return output_dir / "files" / domain / safe_name
+
+
+def _proxy_args(proxy: Optional[str]) -> list[str]:
+    proxy = (
+        proxy
+        or os.environ.get("HTTPS_PROXY")
+        or os.environ.get("https_proxy")
+        or os.environ.get("HTTP_PROXY")
+        or os.environ.get("http_proxy")
+    )
+    return ["--proxy", proxy] if proxy else []
+
+
+def check_one_url(
+    entry: AssetEntry,
+    *,
+    connect_timeout: int,
+    max_time: int,
+    proxy: Optional[str] = None,
+) -> AssetEntry:
+    """Probe a URL without downloading the full file."""
+    curl_base = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--connect-timeout",
+        str(connect_timeout),
+        "--max-time",
+        str(max_time),
+        "--retry",
+        "1",
+        "--user-agent",
+        "gym-anything-asset-check/0.1 (+https://github.com/cmu-l3/gym-anything)",
+        *_proxy_args(proxy),
+    ]
+
+    commands = [
+        [*curl_base, "-I", "-o", "/dev/null", "-w", "%{http_code}", entry.url],
+        [
+            *curl_base,
+            "--range",
+            "0-0",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{http_code}",
+            entry.url,
+        ],
+    ]
+
+    last_error = ""
+    for command in commands:
+        result = subprocess.run(command, capture_output=True, text=True)
+        code = _parse_http_code(result.stdout)
+        if code and code != 405:
+            entry.http_code = code
+            entry.status = "ok" if 200 <= code < 400 else "failed"
+            if entry.status == "failed":
+                entry.error = (result.stderr or "").strip()[:240] or f"HTTP {code}"
+            return entry
+        last_error = (result.stderr or result.stdout or "").strip()
+
+    entry.status = "failed"
+    entry.http_code = None
+    entry.error = last_error[:240] or "No HTTP status returned"
+    return entry
+
+
+def _parse_http_code(text: str) -> Optional[int]:
+    text = (text or "").strip()
+    if not text:
+        return None
+    token = text.split()[-1]
+    try:
+        return int(token)
+    except ValueError:
+        return None
+
+
+def download_one(
+    entry: AssetEntry,
+    output_dir: Path,
+    *,
+    connect_timeout: int,
+    max_time: int,
+    proxy: Optional[str] = None,
+) -> AssetEntry:
+    """Download one URL into the local audit cache."""
+    local_path = url_to_local_path(entry, output_dir)
+    entry.local_path = str(local_path)
+    if local_path.exists() and local_path.stat().st_size > 0:
+        entry.status = "already_exists"
+        entry.size_bytes = local_path.stat().st_size
+        return entry
+
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        "curl",
+        "--silent",
+        "--show-error",
+        "--fail",
+        "--location",
+        "--connect-timeout",
+        str(connect_timeout),
+        "--max-time",
+        str(max_time),
+        "--retry",
+        "2",
+        "--insecure",
+        "-o",
+        str(local_path),
+        "-H",
+        "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36",
+        *_proxy_args(proxy),
+        entry.url,
+    ]
+
+    try:
+        result = subprocess.run(command, capture_output=True, timeout=max_time + 60)
+    except subprocess.TimeoutExpired:
+        entry.status = "timeout"
+        entry.error = "download timed out"
+        local_path.unlink(missing_ok=True)
+        return entry
+
+    if result.returncode == 0 and local_path.exists() and local_path.stat().st_size > 0:
+        entry.status = "downloaded"
+        entry.size_bytes = local_path.stat().st_size
+        return entry
+
+    stderr = result.stderr.decode(errors="replace") if isinstance(result.stderr, bytes) else str(result.stderr)
+    entry.status = "failed"
+    entry.error = stderr[:240]
+    local_path.unlink(missing_ok=True)
+    return entry
+
+
+def _entry_to_dict(entry: AssetEntry) -> dict[str, Any]:
+    data = asdict(entry)
+    data["sources"] = [asdict(source) for source in entry.sources]
+    return data
+
+
+def summarize(entries: list[AssetEntry], filtered: list[dict[str, Optional[str]]]) -> dict[str, Any]:
+    failed = [
+        entry for entry in entries
+        if entry.status in {"failed", "timeout", "error"}
+        or (entry.http_code is not None and not (200 <= entry.http_code < 400))
+    ]
+    affected_tasks = sorted(
+        {
+            used_by
+            for entry in failed
+            for used_by in entry.used_by
+            if not used_by.endswith("/_env_scripts")
+        }
+    )
+    affected_env_scripts = sorted(
+        {
+            used_by
+            for entry in failed
+            for used_by in entry.used_by
+            if used_by.endswith("/_env_scripts")
+        }
+    )
+    status_counts: dict[str, int] = {}
+    domain_counts: dict[str, int] = {}
+    for entry in failed:
+        key = str(entry.http_code) if entry.http_code is not None else (entry.status or "unknown")
+        status_counts[key] = status_counts.get(key, 0) + 1
+        domain = entry.domain or "unknown"
+        domain_counts[domain] = domain_counts.get(domain, 0) + 1
+
+    return {
+        "total_urls": len(entries) + len(filtered),
+        "downloadable_urls": len(entries),
+        "filtered_urls": len(filtered),
+        "checked_or_downloaded_urls": sum(1 for entry in entries if entry.status is not None),
+        "failed_urls": len(failed),
+        "affected_tasks": len(affected_tasks),
+        "affected_env_scripts": len(affected_env_scripts),
+        "failed_status_counts": dict(sorted(status_counts.items())),
+        "failed_domain_counts": dict(
+            sorted(domain_counts.items(), key=lambda item: (-item[1], item[0]))
+        ),
+        "affected_task_ids": affected_tasks,
+        "affected_env_script_ids": affected_env_scripts,
+    }
+
+
+def write_report(
+    output_dir: Path,
+    entries: list[AssetEntry],
+    filtered: list[dict[str, Optional[str]]],
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report = {
+        "summary": summarize(entries, filtered),
+        "entries": [_entry_to_dict(entry) for entry in entries],
+        "filtered_entries": filtered,
+    }
+    path = output_dir / "asset_download_check.json"
+    path.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def _print_text_summary(summary: dict[str, Any], report_path: Optional[Path]) -> None:
+    print("Gym Anything benchmark asset URL audit")
+    print(f"  total external URLs:       {summary['total_urls']}")
+    print(f"  downloadable URLs:         {summary['downloadable_urls']}")
+    print(f"  filtered URLs:             {summary['filtered_urls']}")
+    print(f"  checked/downloaded URLs:   {summary['checked_or_downloaded_urls']}")
+    print(f"  failed URLs:               {summary['failed_urls']}")
+    print(f"  affected task scripts:     {summary['affected_tasks']}")
+    print(f"  affected env scripts:      {summary['affected_env_scripts']}")
+    if summary["failed_status_counts"]:
+        print("  failed status counts:")
+        for status, count in summary["failed_status_counts"].items():
+            print(f"    {status}: {count}")
+    if report_path:
+        print(f"  report: {report_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gym-anything-extras utilities benchmark_assets download_check",
+        description="Scan CUA-World setup scripts for external asset URLs.",
+    )
+    parser.add_argument(
+        "--benchmarks-root",
+        type=Path,
+        default=_default_benchmarks_root(),
+        help="Path to benchmarks/cua_world/environments.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_default_output_dir(),
+        help="Directory for reports and optional downloaded files.",
+    )
+    parser.add_argument(
+        "--all-domains",
+        action="store_true",
+        help="Include every non-skipped URL, not just known asset domains.",
+    )
+    parser.add_argument(
+        "--no-env-scripts",
+        action="store_true",
+        help="Only scan task-level setup_task.sh scripts.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check-links",
+        action="store_true",
+        help="Probe URLs with HEAD/range requests without downloading full files.",
+    )
+    mode.add_argument(
+        "--download",
+        action="store_true",
+        help="Download all discovered asset URLs into the output cache.",
+    )
+    parser.add_argument("--jobs", type=int, default=4, help="Parallel workers.")
+    parser.add_argument("--proxy", default=None, help="HTTP(S) proxy URL.")
+    parser.add_argument("--connect-timeout", type=int, default=30)
+    parser.add_argument("--max-time", type=int, default=300)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print summary JSON instead of text.",
+    )
+    parser.add_argument(
+        "--fail-on-dead",
+        action="store_true",
+        help="Exit 1 when checked/downloaded URLs include failures.",
+    )
+    return parser
+
+
+def _run_parallel(
+    entries: list[AssetEntry],
+    *,
+    jobs: int,
+    worker,
+) -> list[AssetEntry]:
+    completed: list[AssetEntry] = []
+    with ThreadPoolExecutor(max_workers=max(1, jobs)) as pool:
+        futures = {pool.submit(worker, entry): entry for entry in entries}
+        for index, future in enumerate(as_completed(futures), 1):
+            completed.append(future.result())
+            if index % 50 == 0:
+                print(f"  processed {index}/{len(entries)} URLs", file=sys.stderr)
+    return completed
+
+
+def run(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    benchmarks_root = args.benchmarks_root.resolve()
+    output_dir = args.output_dir.resolve()
+
+    entries, filtered = scan_assets(
+        benchmarks_root,
+        all_domains=args.all_domains,
+        include_env_scripts=not args.no_env_scripts,
+    )
+    for entry in entries:
+        entry.local_path = str(url_to_local_path(entry, output_dir))
+
+    if args.check_links:
+        entries = _run_parallel(
+            entries,
+            jobs=args.jobs,
+            worker=lambda entry: check_one_url(
+                entry,
+                connect_timeout=args.connect_timeout,
+                max_time=args.max_time,
+                proxy=args.proxy,
+            ),
+        )
+    elif args.download:
+        entries = _run_parallel(
+            entries,
+            jobs=args.jobs,
+            worker=lambda entry: download_one(
+                entry,
+                output_dir,
+                connect_timeout=args.connect_timeout,
+                max_time=args.max_time,
+                proxy=args.proxy,
+            ),
+        )
+
+    report_path = write_report(output_dir, entries, filtered)
+    summary = summarize(entries, filtered)
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _print_text_summary(summary, report_path)
+
+    if args.fail_on_dead and summary["failed_urls"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/extras/utilities/benchmark_assets/download_check/tests/test_download_check_contract.py
+++ b/extras/utilities/benchmark_assets/download_check/tests/test_download_check_contract.py
@@ -1,0 +1,151 @@
+"""Contract tests for the benchmark asset download_check utility."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from extras.utilities.benchmark_assets.download_check import method as dc  # noqa: E402
+
+
+class ScanAssetsTests(unittest.TestCase):
+    def test_extract_urls_from_wget_curl_python_and_assignment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = Path(tmp) / "setup_task.sh"
+            script.write_text(
+                "\n".join(
+                    [
+                        "wget -q https://imagej.net/images/leaf.jpg -O leaf.jpg",
+                        "curl -L https://github.com/example/release.zip -o release.zip",
+                        "urllib.request.urlretrieve('https://upload.wikimedia.org/a.png', 'a.png')",
+                        "DATA_URL='https://raw.githubusercontent.com/org/repo/main/data.csv'",
+                    ]
+                )
+            )
+            urls = [url for url, _, _ in dc.extract_urls_from_file(script)]
+        self.assertEqual(len(urls), 4)
+        self.assertIn("https://imagej.net/images/leaf.jpg", urls)
+
+    def test_scan_assets_deduplicates_and_records_usage(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            task_a = root / "demo_env" / "tasks" / "task_a"
+            task_b = root / "demo_env" / "tasks" / "task_b"
+            scripts = root / "demo_env" / "scripts"
+            task_a.mkdir(parents=True)
+            task_b.mkdir(parents=True)
+            scripts.mkdir(parents=True)
+            url = "https://imagej.net/images/leaf.jpg"
+            (task_a / "setup_task.sh").write_text(f"wget -q {url} -O leaf.jpg\n")
+            (task_b / "setup_task.sh").write_text(f"curl -L {url} -o leaf.jpg\n")
+            (scripts / "install.sh").write_text(
+                "wget -q https://raw.githubusercontent.com/org/repo/main/file.txt\n"
+            )
+
+            entries, filtered = dc.scan_assets(root)
+
+        self.assertEqual(filtered, [])
+        self.assertEqual(len(entries), 2)
+        leaf = next(entry for entry in entries if entry.url == url)
+        self.assertEqual(leaf.used_by, ["demo_env/task_a", "demo_env/task_b"])
+        self.assertEqual(len(leaf.sources), 2)
+
+    def test_scan_assets_filters_unknown_domains_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task = Path(tmp) / "demo_env" / "tasks" / "task_a"
+            task.mkdir(parents=True)
+            (task / "setup_task.sh").write_text(
+                "wget -q https://unknown.invalid/file.dat -O file.dat\n"
+            )
+
+            entries, filtered = dc.scan_assets(Path(tmp))
+
+        self.assertEqual(entries, [])
+        self.assertEqual(filtered[0]["domain"], "unknown.invalid")
+
+
+class StatusTests(unittest.TestCase):
+    def test_check_one_url_records_failed_status(self):
+        entry = dc.AssetEntry(
+            url="https://imagej.nih.gov/ij/images/missing.tif",
+            domain="imagej.nih.gov",
+            filename="missing.tif",
+        )
+        completed = mock.Mock()
+        completed.stdout = "404"
+        completed.stderr = ""
+        completed.returncode = 0
+        with mock.patch.object(dc.subprocess, "run", return_value=completed):
+            result = dc.check_one_url(entry, connect_timeout=1, max_time=1)
+        self.assertEqual(result.status, "failed")
+        self.assertEqual(result.http_code, 404)
+
+    def test_summarize_counts_failed_tasks_and_env_scripts(self):
+        failed = dc.AssetEntry(
+            url="https://imagej.nih.gov/ij/images/missing.tif",
+            domain="imagej.nih.gov",
+            filename="missing.tif",
+            used_by=["fiji_env/task_a", "fiji_env/_env_scripts"],
+            status="failed",
+            http_code=404,
+        )
+        ok = dc.AssetEntry(
+            url="https://imagej.net/images/leaf.jpg",
+            domain="imagej.net",
+            filename="leaf.jpg",
+            used_by=["fiji_env/task_b"],
+            status="ok",
+            http_code=200,
+        )
+        summary = dc.summarize([failed, ok], [])
+        self.assertEqual(summary["failed_urls"], 1)
+        self.assertEqual(summary["affected_tasks"], 1)
+        self.assertEqual(summary["affected_env_scripts"], 1)
+        self.assertEqual(summary["failed_status_counts"], {"404": 1})
+
+
+class ParserTests(unittest.TestCase):
+    def test_parser_defaults_to_parse_only(self):
+        args = dc.build_parser().parse_args([])
+        self.assertFalse(args.check_links)
+        self.assertFalse(args.download)
+        self.assertFalse(args.all_domains)
+
+    def test_run_writes_report_without_network_when_parse_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            root = tmp_path / "benchmarks"
+            task = root / "demo_env" / "tasks" / "task_a"
+            task.mkdir(parents=True)
+            (task / "setup_task.sh").write_text(
+                "wget -q https://imagej.net/images/leaf.jpg -O leaf.jpg\n"
+            )
+            output = tmp_path / "out"
+
+            rc = dc.run(
+                [
+                    "--benchmarks-root",
+                    str(root),
+                    "--output-dir",
+                    str(output),
+                    "--json",
+                ]
+            )
+
+            report = json.loads((output / "asset_download_check.json").read_text())
+        self.assertEqual(rc, 0)
+        self.assertEqual(report["summary"]["downloadable_urls"], 1)
+        self.assertEqual(report["summary"]["checked_or_downloaded_urls"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/src/gym_anything/extras_cli.py
+++ b/src/gym_anything/extras_cli.py
@@ -109,7 +109,14 @@ def _import_method(method_path: Path):
     if repo_root and str(repo_root) not in sys.path:
         sys.path.insert(0, str(repo_root))
 
-    spec.loader.exec_module(module)
+    # Some module-level decorators (notably dataclasses on Python 3.13)
+    # resolve the module through sys.modules while the file is executing.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
     return module
 
 

--- a/tests/test_extras_cli.py
+++ b/tests/test_extras_cli.py
@@ -68,6 +68,14 @@ class DispatchTests(unittest.TestCase):
         self.assertIn("--software", out)
         self.assertIn("--env-dir", out)
 
+    def test_download_check_method_help_dispatched(self):
+        rc, out, _ = self._capture(
+            ["utilities", "benchmark_assets", "download_check", "--help"]
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("--check-links", out)
+        self.assertIn("--download", out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `gym-anything-extras utilities benchmark_assets download_check` for parsing, probing, or downloading external benchmark asset URLs
- adapt the utility from the script shared by Tianbao Xie / @Timothyxxx in #2, with attribution in the method and README
- fix extras dynamic imports so dataclass-based methods load correctly through the dispatcher
- ignore the generated `gym_anything_asset_audit` output directory

Refs #2

## Tests
- `python -m pytest extras/utilities/benchmark_assets/download_check/tests/test_download_check_contract.py tests/test_extras_cli.py -q`
- `PYTHONPATH=src python -m pytest tests -q`

Note: bare `python -m pytest tests -q` fails in this checkout unless the package is installed or `PYTHONPATH=src` is set.