### PR TITLE
Remote stack robustness: client retries + stale-pending recovery

### DIFF
--- a/src/gym_anything/remote/client.py
+++ b/src/gym_anything/remote/client.py
@@ -23,11 +23,25 @@ Usage:
 from __future__ import annotations
 
 import json
+import logging
 import os
+import random
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
+
+logger = logging.getLogger(__name__)
+
+# Transient failure retry policy. Tuned for a flaky master/worker link (5xx
+# from the master when no healthy worker is momentarily available, dropped
+# connections, idle-timeout reads on long resets, etc.). 4xx and other
+# requests.exceptions are not retried.
+_RETRYABLE_STATUSES = frozenset({500, 502, 503, 504})
+_DEFAULT_RETRY_ATTEMPTS = int(os.environ.get("GYM_ANYTHING_REMOTE_RETRY_ATTEMPTS", "5"))
+_DEFAULT_RETRY_BASE_SEC = float(os.environ.get("GYM_ANYTHING_REMOTE_RETRY_BASE_SEC", "1.0"))
+_DEFAULT_RETRY_MAX_SEC = float(os.environ.get("GYM_ANYTHING_REMOTE_RETRY_MAX_SEC", "30.0"))
 
 from gym_anything.contracts import SessionInfo
 from gym_anything.config.loading import _load_envspec, _load_taskspec
@@ -177,13 +191,12 @@ class RemoteGymEnv:
         if runner_hint:
             data["runner"] = runner_hint
 
-        # Send request
-        response = requests.post(
+        # Send request (with transient-error retries)
+        response = self._http_with_retries(
+            "POST",
             f"{self.remote_url}/envs/create",
             json=data,
-            timeout=self.timeout
         )
-        response.raise_for_status()
 
         result = response.json()
         self.env_id = result["env_id"]
@@ -242,23 +255,71 @@ class RemoteGymEnv:
 
         return env_spec, task_spec
         
-    def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
-        """Make HTTP request to remote server with error handling."""
-        if self._closed:
-            raise RuntimeError("Environment has been closed")
-        
-        url = f"{self.remote_url}{endpoint}"
-        
-        # Add default timeout if not specified
+    def _http_with_retries(self, method: str, url: str, **kwargs) -> requests.Response:
+        """Issue an HTTP request, retrying transient failures with exponential
+        backoff + full jitter. Retries on connection errors, timeouts, and
+        5xx responses (500/502/503/504). 4xx errors are surfaced immediately.
+
+        Caveat: /envs/create and /envs/<id>/step are not strictly idempotent;
+        a retry after a partial success may produce a duplicate side effect.
+        That is preferable to losing the whole run on a transient master/worker
+        hiccup; tune attempts via GYM_ANYTHING_REMOTE_RETRY_ATTEMPTS=0 to
+        disable.
+        """
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self.timeout
-        
-        try:
-            response = requests.request(method, url, **kwargs)
-            response.raise_for_status()
-            return response
-        except requests.exceptions.RequestException as e:
-            raise RuntimeError(f"Remote request failed: {e}") from e
+
+        attempts = max(1, _DEFAULT_RETRY_ATTEMPTS)
+        last_exc: Optional[BaseException] = None
+        for attempt in range(1, attempts + 1):
+            try:
+                response = requests.request(method, url, **kwargs)
+                if response.status_code in _RETRYABLE_STATUSES and attempt < attempts:
+                    body = (response.text or "")[:200]
+                    delay = min(_DEFAULT_RETRY_MAX_SEC,
+                                _DEFAULT_RETRY_BASE_SEC * (2 ** (attempt - 1)))
+                    delay = random.uniform(0, delay)
+                    logger.warning(
+                        "remote %s %s -> HTTP %d (attempt %d/%d); retrying in %.1fs: %s",
+                        method, url, response.status_code, attempt, attempts, delay, body,
+                    )
+                    time.sleep(delay)
+                    continue
+                response.raise_for_status()
+                return response
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                requests.exceptions.ChunkedEncodingError,
+            ) as exc:
+                last_exc = exc
+                if attempt >= attempts:
+                    break
+                delay = min(_DEFAULT_RETRY_MAX_SEC,
+                            _DEFAULT_RETRY_BASE_SEC * (2 ** (attempt - 1)))
+                delay = random.uniform(0, delay)
+                logger.warning(
+                    "remote %s %s -> %s (attempt %d/%d); retrying in %.1fs",
+                    method, url, type(exc).__name__, attempt, attempts, delay,
+                )
+                time.sleep(delay)
+                continue
+            except requests.exceptions.HTTPError as exc:
+                # 4xx (or 5xx on the final attempt) — do not retry further.
+                raise RuntimeError(f"Remote request failed: {exc}") from exc
+            except requests.exceptions.RequestException as exc:
+                raise RuntimeError(f"Remote request failed: {exc}") from exc
+
+        raise RuntimeError(
+            f"Remote request failed after {attempts} attempts: {last_exc}"
+        ) from last_exc
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> requests.Response:
+        """Make HTTP request to remote server with retries on transient errors."""
+        if self._closed:
+            raise RuntimeError("Environment has been closed")
+        url = f"{self.remote_url}{endpoint}"
+        return self._http_with_retries(method, url, **kwargs)
     
     # ========================================================================
     # Main Gym Interface

--- a/src/gym_anything/remote/master.py
+++ b/src/gym_anything/remote/master.py
@@ -511,14 +511,79 @@ class WorkerRegistry:
                         f"(envs={worker.env_count}, pending={worker.pending_count})")
             return True
 
-    async def reset_pending_counts(self):
-        """Reset all pending counts to 0 (for recovery from stuck state)."""
+    async def reset_pending_counts(
+        self,
+        *,
+        min_age_sec: float = 0.0,
+        dry_run: bool = False,
+    ) -> Dict[str, Any]:
+        """Reset stale pending reservations and return a recovery summary.
+
+        Pending reservations are scheduler bookkeeping for in-flight env
+        creation. If the client connection dies after reserving a slot, the
+        worker may never receive a request and the reservation can block
+        scheduling even though the worker has actual capacity. This endpoint is
+        intentionally separate from closing environments.
+        """
+        now = time.time()
+        reset_workers: List[Dict[str, Any]] = []
+        total_pending_before = 0
+        total_reset = 0
+
         async with self._lock:
             for worker in self._workers.values():
-                if worker.pending_count > 0:
-                    logger.warning(f"Resetting pending_count={worker.pending_count} on {worker.worker_id}")
-                    worker.pending_count = 0
-            self._pending_timestamps.clear()
+                pending_before = worker.pending_count
+                total_pending_before += pending_before
+                if pending_before <= 0:
+                    continue
+
+                timestamps = self._pending_timestamps.get(worker.worker_id, [])
+                if min_age_sec <= 0:
+                    reset_count = pending_before
+                    remaining_timestamps: List[float] = []
+                elif timestamps:
+                    stale_timestamps = [ts for ts in timestamps if now - ts >= min_age_sec]
+                    reset_count = min(len(stale_timestamps), pending_before)
+                    remaining_timestamps = [ts for ts in timestamps if now - ts < min_age_sec]
+                else:
+                    reset_count = 0
+                    remaining_timestamps = []
+
+                if reset_count <= 0:
+                    continue
+
+                total_reset += reset_count
+                reset_workers.append({
+                    "worker_id": worker.worker_id,
+                    "hostname": worker.hostname,
+                    "pending_before": pending_before,
+                    "pending_reset": reset_count,
+                    "pending_after": pending_before - reset_count,
+                    "env_count": worker.env_count,
+                    "max_envs": worker.max_envs,
+                })
+
+                if dry_run:
+                    continue
+
+                worker.pending_count = max(0, pending_before - reset_count)
+                if worker.pending_count == 0:
+                    self._pending_timestamps.pop(worker.worker_id, None)
+                else:
+                    self._pending_timestamps[worker.worker_id] = remaining_timestamps[-worker.pending_count:]
+
+                logger.warning(
+                    f"Reset {reset_count} pending reservation(s) on {worker.worker_id} "
+                    f"(pending {pending_before}->{worker.pending_count}, min_age_sec={min_age_sec})"
+                )
+
+        return {
+            "dry_run": dry_run,
+            "min_age_sec": min_age_sec,
+            "total_pending_before": total_pending_before,
+            "total_pending_reset": total_reset,
+            "workers": reset_workers,
+        }
 
     async def cleanup_stale_pending(self):
         """Clean up stale pending reservations.
@@ -1272,6 +1337,32 @@ async def list_workers():
         return jsonify(stats)
     except Exception as e:
         logger.error(f"List workers error: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/admin/pending/reset', methods=['POST'])
+async def reset_pending_reservations_endpoint():
+    """Reset stale pending scheduler reservations.
+
+    This recovers capacity after client or tunnel failures during env creation.
+    It does not close environments or alter worker processes.
+    """
+    try:
+        data = await request.get_json(silent=True) or {}
+        min_age_sec = float(data.get("min_age_sec", 0.0))
+        dry_run = bool(data.get("dry_run", False))
+
+        if min_age_sec < 0:
+            return jsonify({"error": "min_age_sec must be non-negative"}), 400
+
+        summary = await registry.reset_pending_counts(
+            min_age_sec=min_age_sec,
+            dry_run=dry_run,
+        )
+        return jsonify(summary)
+
+    except Exception as e:
+        logger.error(f"Reset pending reservations error: {e}")
         return jsonify({"error": str(e)}), 500
 
 

--- a/tests/test_remote_client.py
+++ b/tests/test_remote_client.py
@@ -84,7 +84,7 @@ class RemoteClientResetPolicyTests(unittest.TestCase):
         }
 
         with mock.patch.dict(os.environ, verifier_env, clear=True), \
-             mock.patch("gym_anything.remote.client.requests.post", return_value=response) as post, \
+             mock.patch("gym_anything.remote.client.requests.request", return_value=response) as post, \
              mock.patch.object(RemoteGymEnv, "_setup_cache"):
             RemoteGymEnv.from_config(
                 remote_url="http://localhost:5000",
@@ -93,6 +93,7 @@ class RemoteClientResetPolicyTests(unittest.TestCase):
             )
 
         response.raise_for_status.assert_called_once()
+        self.assertEqual(post.call_args.args[0], "POST")
         payload = post.call_args.kwargs["json"]
         self.assertEqual(payload["env_dir"], "demo-env")
         self.assertEqual(payload["task_id"], "demo-task")


### PR DESCRIPTION
## What

Two reliability fixes for running large parallel evals through the remote master/worker stack.

**`remote/client.py` — transient-error retries.** Every HTTP call from `RemoteGymEnv` to the master now goes through a retry wrapper: connection errors, timeouts, and 5xx responses (500/502/503/504) retry with exponential backoff + full jitter; 4xx surface immediately. Before this, a single dropped connection or momentary `503` (e.g. no healthy worker for an instant) killed the whole rollout. Tunable via `GYM_ANYTHING_REMOTE_RETRY_ATTEMPTS` (0 disables), `..._RETRY_BASE_SEC`, `..._RETRY_MAX_SEC`.

Caveat (documented in-code): `/envs/create` and `/step` are not strictly idempotent — a retry after a partial success can duplicate a side effect. That trade is preferable to losing runs; set attempts=0 to opt out.

**`remote/master.py` — stale-pending recovery.** Pending reservations are scheduler bookkeeping for in-flight env creation; when a client dies mid-create they leak and block scheduling although the worker has capacity. `reset_pending_counts()` now takes `min_age_sec` (only reset reservations older than N sec — safe to call while creates are in flight) and `dry_run`, and returns a per-worker summary. Exposed as `POST /admin/pending/reset` so capacity can be reclaimed without restarting the master or touching live envs.

**`tests/test_remote_client.py`** updated: the create-env test now mocks `requests.request` (the retry wrapper's entry point) and asserts the HTTP method.

## Scope

Only these 3 files. No behavior change on the happy path (single successful request = identical flow).

## Testing

`python -m pytest tests -q` → 109 passed, 1 skipped (the one prior failure was this test-mock mismatch, fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)