### PR TITLE
Core infra: batch-run coordination, disk split, keys_down/up actions, tunable hook timeout

### DIFF
--- a/benchmarks/cua_world/registry/splits.py
+++ b/benchmarks/cua_world/registry/splits.py
@@ -8,6 +8,12 @@ from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
 DEFAULT_SPLITS_ROOT = Path(__file__).resolve().parents[1] / "splits"
 DEFAULT_ENVIRONMENTS_ROOT = Path(__file__).resolve().parents[1] / "environments"
 
+# Reserved split name: every task folder physically present under
+# ``<env>/tasks/``, regardless of split-file curation or surface. This is the
+# escape hatch for running tasks that exist on disk but were never listed in a
+# split file. Always reflects the directory, so split files cannot override it.
+DISK_SPLIT = "disk"
+
 
 def _dedupe_preserve_order(values: Iterable[str]) -> List[str]:
     ordered: List[str] = []
@@ -189,6 +195,11 @@ def load_environment_task_splits(
             "verified": list(task_ids),
         }
 
+    # Reserved 'disk' split: the literal directory listing, surface-independent.
+    # Reflects every task folder on disk even if it is absent from the split file.
+    for env_name in registry:
+        registry[env_name][DISK_SPLIT] = list(discovered_tasks.get(env_name, []))
+
     return {env_name: registry[env_name] for env_name in sorted(registry)}
 
 
@@ -217,6 +228,7 @@ def get_tasks_for_environment(
 __all__ = [
     "DEFAULT_ENVIRONMENTS_ROOT",
     "DEFAULT_SPLITS_ROOT",
+    "DISK_SPLIT",
     "get_tasks_for_environment",
     "load_environment_task_splits",
     "resolve_environment_dir",

--- a/docs/content/docs/benchmarks/index.mdx
+++ b/docs/content/docs/benchmarks/index.mdx
@@ -151,6 +151,12 @@ You'll also see names such as `train`, `test`, `all`, and `verified`.
 
 These are named lists of tasks. They're mainly used when you want to run many tasks together.
 
+There's also a reserved `disk` split. It isn't read from the split file — it's the
+literal listing of every task folder under `<env>/tasks/`. Use `--split disk` to run a
+task that exists on disk but was never added to a split file. Note that `all` is
+curated: it's the union of `train` and `test` from the split file, so a folder missing
+from both won't appear in `all` even though it's on disk.
+
 <Callout type="info">
 If you're only trying one task by hand, you don't need split files yet.
 </Callout>

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -64,7 +64,7 @@ Important flags:
 - `--task`: task ID. Omit to run all tasks in the split (batch mode)
 - `--model`: model identifier (e.g. `claude-opus-4`)
 - `--steps`: max steps per task (default: 50)
-- `--split`: task split for batch mode (default: `test`)
+- `--split`: task split for batch mode (default: `test`). Use `disk` to run every task folder on disk, ignoring split files
 - `--parallel`, `--jobs`: batch task processes to run at once
 - `--max-tasks`: limit the number of tasks in batch mode
 - `--agent-arg KEY=VALUE`: extra agent argument (repeatable)

--- a/src/gym_anything/cli.py
+++ b/src/gym_anything/cli.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import json
 import os
+import random
 import subprocess
 import sys
 import time
@@ -432,6 +434,40 @@ def _run_benchmark_batch(args) -> int:
     if not pairs:
         print(f"No tasks found for split '{args.split}'.", file=sys.stderr)
         return 1
+
+    min_runs = getattr(args, "min_runs", None)
+
+    def _runs_done(task_id: str) -> bool:
+        # With --min-runs N: a task is "done" once it has N completed runs
+        # (run_*/info.json). Otherwise (plain --skip-existing): done if any run_* exists.
+        base = f"all_runs/{args.exp_name}/{args.model}/{task_id}"
+        if min_runs:
+            return len(glob.glob(f"{base}/run_*/info.json")) >= int(min_runs)
+        return bool(glob.glob(f"{base}/run_*"))
+
+    if getattr(args, "skip_existing", False) or min_runs:
+        if not args.exp_name or not args.model:
+            print("--skip-existing/--min-runs ignored: requires --exp-name and --model to locate output dirs.",
+                  file=sys.stderr)
+        else:
+            # Mirror the reference agents' save path: all_runs/<exp>/<model>/<task>/run_*
+            kept, skipped = [], 0
+            for task_id, env_dir in pairs:
+                if _runs_done(task_id):
+                    skipped += 1
+                else:
+                    kept.append((task_id, env_dir))
+            label = f"--min-runs {min_runs}" if min_runs else "--skip-existing"
+            print(f"{label}: skipping {skipped} satisfied task(s), {len(kept)} remain")
+            pairs = kept
+            if not pairs:
+                print("All tasks already satisfied; nothing to run.")
+                return 0
+            # Randomize order so concurrent workers diverge instead of marching the
+            # list in lockstep (which would re-do the same tasks). Combined with the
+            # per-task recheck below, this lets many parallel workers share the load.
+            random.shuffle(pairs)
+
     max_tasks = getattr(args, "max_tasks", None)
     if max_tasks is not None:
         pairs = pairs[:max_tasks]
@@ -469,6 +505,12 @@ def _run_benchmark_batch(args) -> int:
         return cmd
 
     def run_one(index: int, task_id: str, env_dir: str) -> tuple[int, str, str, int]:
+        # Re-check right before launch: another concurrent worker may have produced
+        # output for this task since the startup filter ran.
+        if ((getattr(args, "skip_existing", False) or min_runs) and args.exp_name and args.model
+                and _runs_done(task_id)):
+            print(f"[{index}/{len(pairs)}] SKIP {Path(env_dir).name} / {task_id} (satisfied)", flush=True)
+            return index, task_id, env_dir, 0
         print(f"\n[{index}/{len(pairs)}] START {Path(env_dir).name} / {task_id}", flush=True)
         result = subprocess.run(build_command(task_id, env_dir), check=False)
         return index, task_id, env_dir, result.returncode
@@ -1141,9 +1183,13 @@ def main(argv=None):
     p_bench.add_argument("--steps", type=int, help="Max steps per task (overrides task.json; falls back to task.json, then 50)")
     p_bench.add_argument("--seed", type=int, default=42)
     p_bench.add_argument("--temperature", type=float, help="Sampling temperature")
-    p_bench.add_argument("--split", default="test", help="Task split for batch mode (default: test)")
+    p_bench.add_argument("--split", default="test", help="Task split for batch mode (default: test). Use 'disk' to run every task folder on disk, ignoring split files.")
     p_bench.add_argument("--parallel", "--jobs", type=int, default=1, help="Batch task processes to run at once")
     p_bench.add_argument("--max-tasks", type=int, help="Limit the number of tasks in batch mode")
+    p_bench.add_argument("--skip-existing", action="store_true",
+                         help="In batch mode, skip tasks that already have output at all_runs/<exp>/<model>/<task>/run_* (requires --exp-name and --model).")
+    p_bench.add_argument("--min-runs", type=int, default=None,
+                         help="In batch mode, run each task until it has N completed trajectories (run_*/info.json), then skip it. Drives multi-trajectory sampling with many parallel workers (requires --exp-name and --model).")
     p_bench.add_argument("--surface", choices=("raw", "verified"), default="raw")
     p_bench.add_argument("--use-cache", action="store_true")
     p_bench.add_argument("--cache-level", default="pre_start")

--- a/src/gym_anything/env.py
+++ b/src/gym_anything/env.py
@@ -26,6 +26,11 @@ import uuid
 
 logger = logging.getLogger(__name__)
 
+# Timeout (seconds) for the pre_start/post_start provisioning hooks. Configurable so
+# envs with very long installs (e.g. virtualmin's installer) are not cut off when their
+# checkpoint is built. Default 1800s preserves prior behaviour.
+HOOK_TIMEOUT = int(os.environ.get("GYM_ANYTHING_HOOK_TIMEOUT", "1800"))
+
 
 class GymAnythingEnv:
     """Unified environment wrapper exposing Gym-like API.
@@ -464,7 +469,7 @@ class GymAnythingEnv:
                     elif self._platform_family() == "windows":
                         self._runner.exec(hook_cmd)
                     else:
-                        self._runner.exec(f"bash -lc {hook_cmd} > /home/ga/env_setup_pre_start.log 2>&1", timeout=1800)
+                        self._runner.exec(f"bash -lc {hook_cmd} > /home/ga/env_setup_pre_start.log 2>&1", timeout=HOOK_TIMEOUT)
                     if self._reporter:
                         self._reporter.stage_done("pre_start_hook")
                 except Exception as e:
@@ -505,7 +510,7 @@ class GymAnythingEnv:
                     elif self._platform_family() == "windows":
                         self._runner.exec(hook_cmd)
                     else:
-                        self._runner.exec(f"bash -lc {hook_cmd} > /home/ga/env_setup_post_start.log 2>&1", timeout=1800)
+                        self._runner.exec(f"bash -lc {hook_cmd} > /home/ga/env_setup_post_start.log 2>&1", timeout=HOOK_TIMEOUT)
                     if self._reporter:
                         self._reporter.stage_done("post_start_hook")
                 except Exception as e:

--- a/src/gym_anything/runtime/runners/qemu_apptainer.py
+++ b/src/gym_anything/runtime/runners/qemu_apptainer.py
@@ -1795,6 +1795,20 @@ class QemuApptainerRunner(BaseRunner):
                 keys_norm = [self._normalize_key_name(k) for k in keys]
                 keys_str = ", ".join(f"'{k}'" for k in keys_norm)
                 commands.append(f"pyautogui.hotkey({keys_str})")
+            # keys_down / keys_up support modifier-held clicks and hold_key by
+            # decomposing those gestures into a held-modifier sequence.
+            if "keys_down" in keyboard:
+                keys = keyboard["keys_down"]
+                if isinstance(keys, str):
+                    keys = [keys]
+                for k in keys:
+                    commands.append(f"pyautogui.keyDown('{self._normalize_key_name(k)}')")
+            if "keys_up" in keyboard:
+                keys = keyboard["keys_up"]
+                if isinstance(keys, str):
+                    keys = [keys]
+                for k in keys:
+                    commands.append(f"pyautogui.keyUp('{self._normalize_key_name(k)}')")
 
         if commands:
             print(f"[QemuApptainer] Executing pyautogui commands: {commands}")
@@ -1858,6 +1872,19 @@ class QemuApptainerRunner(BaseRunner):
                     # Normalize key names
                     keys_norm = [self._normalize_key_name(k) for k in keys]
                     self._pyautogui_client.hotkey(*keys_norm)
+                # keys_down / keys_up support modifier-held clicks and hold_key.
+                if "keys_down" in keyboard:
+                    keys = keyboard["keys_down"]
+                    if isinstance(keys, str):
+                        keys = [keys]
+                    for k in keys:
+                        self._pyautogui_client.key_down(self._normalize_key_name(k))
+                if "keys_up" in keyboard:
+                    keys = keyboard["keys_up"]
+                    if isinstance(keys, str):
+                        keys = [keys]
+                    for k in keys:
+                        self._pyautogui_client.key_up(self._normalize_key_name(k))
 
         except PyAutoGUIClientError as e:
             print(f"[QemuApptainer] PyAutoGUI client error: {e}")

--- a/tests/test_benchmark_registry.py
+++ b/tests/test_benchmark_registry.py
@@ -63,6 +63,54 @@ class BenchmarkRegistryTests(unittest.TestCase):
             self.assertEqual(verified["demo_env"]["train"], ["task_c"])
             self.assertEqual(verified["demo_env"]["test"], ["task_b"])
 
+    def test_disk_split_lists_all_task_folders_ignoring_split_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            environments_root = root / "benchmarks" / "cua_world" / "environments"
+            splits_root = root / "benchmarks" / "cua_world" / "splits"
+            env_dir = environments_root / "demo_env"
+            # task_orphan exists on disk but is listed in no split.
+            for task_id in ("task_a", "task_b", "task_orphan"):
+                (env_dir / "tasks" / task_id).mkdir(parents=True)
+
+            _write_json(
+                splits_root / "demo_split.json",
+                {
+                    "env_folder": "benchmarks/cua_world/environments/demo_env",
+                    "train_tasks": ["task_a"],
+                    "test_tasks": ["task_b"],
+                },
+            )
+            _write_json(
+                splits_root / "verified.json",
+                {"by_environment": {"demo_env": ["task_a"]}},
+            )
+
+            for surface in ("raw", "verified"):
+                self.assertEqual(
+                    get_tasks_for_environment(
+                        "demo_env",
+                        split="disk",
+                        surface=surface,
+                        splits_root=splits_root,
+                        environments_root=environments_root,
+                    ),
+                    ["task_a", "task_b", "task_orphan"],
+                    msg=f"disk split should be surface-independent (surface={surface})",
+                )
+
+            # 'all' stays curated: union of train+test, no orphan.
+            self.assertEqual(
+                get_tasks_for_environment(
+                    "demo_env",
+                    split="all",
+                    surface="raw",
+                    splits_root=splits_root,
+                    environments_root=environments_root,
+                ),
+                ["task_a", "task_b"],
+            )
+
     def test_loader_discovers_missing_split_files_from_environment_dirs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## What

Four independent core/runtime improvements, kept in one PR as they're all small and infra-scoped.

### 1. Batch-run coordination — `--skip-existing` / `--min-runs N` (`cli.py`)
For running one benchmark list across many parallel workers:
- `--skip-existing`: skip tasks that already have output at `all_runs/<exp>/<model>/<task>/run_*`.
- `--min-runs N`: a task is satisfied once it has N completed trajectories (`run_*/info.json`) — drives multi-trajectory sampling.
- Task order is shuffled and each task is rechecked right before launch, so concurrent workers diverge instead of marching the list in lockstep. Both flags require `--exp-name`/`--model` (warn + ignore otherwise).

### 2. Reserved `disk` split (`registry/splits.py` + docs + test)
`--split disk` = the literal directory listing of `<env>/tasks/`, surface-independent, immune to split-file curation. The escape hatch for running tasks that exist on disk but were never added to a split file (`all` is curated train∪test and won't see them). Documented in `docs/benchmarks/index.mdx` and `docs/reference/cli.mdx`; new test covers disk vs `all` behavior.

### 3. `keys_down` / `keys_up` keyboard actions (`qemu_apptainer.py`)
Runner support for holding keys, in both the SSH-pyautogui and client paths. This is what enables modifier-held clicks (shift-click etc.) and `hold_key` emitted by the updated agent parser in #29. Independent to merge; #29's held-key gestures become effective once both are in.

### 4. Tunable hook timeout (`env.py`)
`GYM_ANYTHING_HOOK_TIMEOUT` env var for the pre_start/post_start hook timeout (default 1800s = exact prior behavior). Long installs (e.g. virtualmin) were getting cut off at checkpoint build time.

## Scope
No contract changes (`contracts.py`, `specs.py`, public API untouched). Applied on top of current main — coexists with #26's `restrict=on` net isolation in the same runner file.

## Testing
`python -m pytest tests -q` → **110 passed, 1 skipped** (109 pre-existing + the new disk-split test). CLI flags verified registered via `run --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)