### PR TITLE
prime-rl: pull agents deps so the cua-world env loads (litellm)

### DIFF
--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.5"
+version = "0.1.6"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [
@@ -15,7 +15,11 @@ dependencies = [
     # breaks the hub integration test (the path does not exist in Prime's
     # harness). For local development, install with --no-deps against an
     # editable gym-anything already present in the venv (see README).
-    "gym-anything[modal,prime-rl,benchmark] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.3",
+    # `agents` is named explicitly (belt-and-suspenders) so the reference agent
+    # registry's runtime deps (litellm etc.) install even if the prime-rl extra
+    # resolution ever regresses; the tag must post-date the prime_rl subpackage
+    # reorg and the prime-rl-pulls-agents fix.
+    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.4",
 ]
 tags = ["computer-use", "gui", "multi-turn", "vision", "tool-use", "multimodal", "real-world", "train", "eval"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,11 @@ modal = [
 prime-rl = [
     "datasets>=2.16",
     "verifiers>=0.1.14",
+    # The prime-rl rollout drives a real reference agent (agents.agents), whose
+    # registry import pulls in every agent class (e.g. litellm via ClaudeAgent),
+    # so gym-anything[prime-rl] must carry the agents runtime deps or the env
+    # fails to load with ModuleNotFoundError.
+    "gym-anything[agents]",
 ]
 all = [
     "gym-anything[benchmark,agents,services,vlm,modal,prime-rl]",


### PR DESCRIPTION
## Problem
The published `cua-world` env failed to load on the Prime hub with `ModuleNotFoundError: No module named 'litellm'` (eval `nhy2mr6a6h0cdl2lpw689act`: FAILED, 0 samples). The prime-rl rollout imports the `agents.agents` registry, which eagerly imports every agent (`ClaudeAgent` → `litellm`), but `gym-anything[prime-rl]` never installed the agents runtime deps.

Root cause: on `main` the `prime-rl` extra is only `datasets + verifiers`, and the older self-referential form (`gym-anything[...,prime-rl]`) short-circuits in uv and drops the co-listed `agents` extra. Either way litellm is absent. Verified by resolving the exact published pin in a clean env (litellm not in the 172 resolved packages).

## Fix
- **gym-anything**: `prime-rl` extra now pulls `gym-anything[agents]`, so `gym-anything[prime-rl]` is self-sufficient. Verified: `[prime-rl]` resolves litellm in a clean env.
- **cua-world hub package**: pin `gym-anything[modal,prime-rl,benchmark,agents]@gym-anything-cua-v0.1.4` (agents named explicitly as belt-and-suspenders) and bump to 0.1.6.

## Release steps after merge
Cut tag `gym-anything-cua-v0.1.4` on the merged main commit (must post-date the prime_rl subpackage reorg + this fix), then `prime env push` the cua-world package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)