### PR TITLE
prime-rl: log the full multi-turn trajectory (render_completion)

### DIFF
--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.6"
+version = "0.1.7"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [
@@ -19,7 +19,7 @@ dependencies = [
     # registry's runtime deps (litellm etc.) install even if the prime-rl extra
     # resolution ever regresses; the tag must post-date the prime_rl subpackage
     # reorg and the prime-rl-pulls-agents fix.
-    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.4",
+    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.5",
 ]
 tags = ["computer-use", "gui", "multi-turn", "vision", "tool-use", "multimodal", "real-world", "train", "eval"]
 

--- a/src/gym_anything/integrations/prime_rl/verifiers.py
+++ b/src/gym_anything/integrations/prime_rl/verifiers.py
@@ -103,6 +103,13 @@ def _completion_text(completion: Any) -> str:
     return str(content or "")
 
 
+def _role(message: Any) -> Optional[str]:
+    """Role of an OpenAI-style message (dict) or a vf.Message object."""
+    if isinstance(message, dict):
+        return message.get("role")
+    return getattr(message, "role", None)
+
+
 class RolloutAborted(Exception):
     """Raised inside the agent thread when the rollout is torn down."""
 
@@ -425,6 +432,35 @@ class GymAnythingAgentEnv(vf.MultiTurnEnv):
             "unused: get_prompt_messages is overridden; each turn's messages "
             "come from the agent's own step()"
         )
+
+    async def render_completion(self, state: "vf.State") -> None:
+        """Record the FULL multi-turn trajectory, not just the last windowed turn.
+
+        verifiers' default ``render_completion`` serialises only
+        ``state["trajectory"][-1]`` because it assumes append-only prompts. Our
+        agent rebuilds a windowed prompt each turn, so the default drops every
+        prior screenshot and action, leaving a single-turn log. Every turn is
+        already in ``state["trajectory"]``; stitch each turn's new observation
+        (the trailing user message of its windowed prompt) and action into one
+        conversation so the recorded completion is the whole episode.
+
+        Logging-only: this runs from a ``@cleanup`` handler after the rollout, so
+        it never feeds the agent, and it does not affect the reward (which comes
+        from the env verifier via ``state["episode_reward"]``).
+        """
+        traj = state.get("trajectory") or []
+        if not traj:
+            state["completion"] = []
+            return
+        # Turn 0's action answers the observation already carried by state["prompt"].
+        conversation: List[Any] = list(traj[0]["completion"])
+        for step in traj[1:]:
+            user_msgs = [m for m in step["prompt"] if _role(m) == "user"]
+            conversation += user_msgs[-1:] + list(step["completion"])
+        final_resp = state.get("final_env_response")
+        if final_resp:
+            conversation += final_resp if isinstance(final_resp, list) else [final_resp]
+        state["completion"] = conversation
 
     async def _terminate(self, state: vf.State) -> "vf.Messages":
         """Score while the VM is alive, then signal rollout completion."""


### PR DESCRIPTION
## Problem
The recorded eval sample (Prime viewer) showed only the last windowed turn, not the full 15-turn episode. Our agent windows its prompt each turn; verifiers' default `render_completion` serialises only `state["trajectory"][-1]` (assumes append-only prompts), dropping every prior screenshot + action.

## Fix
Override `render_completion` in `GymAnythingAgentEnv` to stitch every turn's new observation + action from `state["trajectory"]` into one conversation. **Logging-only**: it runs from a `@cleanup` handler after the rollout, so it does not change agent behavior or the reward (`state["episode_reward"]` from the env verifier). 38 prime-rl/verifiers tests pass.

Bumps cua-world hub package to 0.1.7, pin `gym-anything-cua-v0.1.5`.

## Release after merge
Cut tag `gym-anything-cua-v0.1.5`, then `prime env push`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)