### PR TITLE
cua-world hub: default env_names to gimp_env_all_fast

### DIFF
--- a/extras/hubs/prime/cua_world/cua_world.py
+++ b/extras/hubs/prime/cua_world/cua_world.py
@@ -21,7 +21,7 @@ Usage:
     vf-eval cua-world -m gemini-3.5-flash \
         -b https://generativelanguage.googleapis.com/v1beta/openai/ \
         -k GEMINI_API_KEY -n 1 -r 1 \
-        -a '{"env_names": ["gimp_env"], "task_ids": ["horizontal_mirror"]}'
+        -a '{"env_names": ["gimp_env_all_fast"], "task_ids": ["add_border"]}'
 """
 
 from gym_anything.integrations.prime_rl.hub import make_hub_loader
@@ -29,7 +29,7 @@ from gym_anything.integrations.prime_rl.hub import make_hub_loader
 load_environment = make_hub_loader(
     "cua_world",
     env_id="cua-world",
-    env_names="gimp_env",
+    env_names="gimp_env_all_fast",
     runner="modal",
     # Drive a real reference agent by name, exactly like --agent locally.
     agent="Qwen3VLAgent",

--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.7"
+version = "0.1.8"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Switch the published env default from `gimp_env` to `gimp_env_all_fast` (the fast GIMP variant used for the RL config and prior evals). Override per-run with `env_args={"env_names":[...]}`. Bump to 0.1.8. Package-only, no gym-anything tag change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)