### PR TITLE
prime-rl: persist verifier verdict + sub-scores into eval output

### DIFF
--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.8"
+version = "0.1.9"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [
@@ -19,7 +19,7 @@ dependencies = [
     # registry's runtime deps (litellm etc.) install even if the prime-rl extra
     # resolution ever regresses; the tag must post-date the prime_rl subpackage
     # reorg and the prime-rl-pulls-agents fix.
-    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.5",
+    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.6",
 ]
 tags = ["computer-use", "gui", "multi-turn", "vision", "tool-use", "multimodal", "real-world", "train", "eval"]
 

--- a/src/gym_anything/integrations/prime_rl/verifiers.py
+++ b/src/gym_anything/integrations/prime_rl/verifiers.py
@@ -287,6 +287,33 @@ def _finalize_episode(state: "vf.State") -> None:
         state["finalize_error"] = traceback.format_exc()[-2000:]
 
 
+def _surface_verifier_info(state: "vf.State") -> None:
+    """Persist the verifier's full verdict into ``state["info"]``.
+
+    ``state["info"]`` is always serialised into the saved rollout output
+    (``state_to_output``), unlike arbitrary state keys, so this makes the score
+    breakdown and reasoning visible in the eval samples/dashboard instead of
+    being computed and dropped. Logging-only; does not touch the reward.
+    """
+    verifier = state.get("verifier") or {}
+    scores = verifier.get("scores") or {}
+    info = state.get("info")
+    if not isinstance(info, dict):
+        info = {}
+    info["verifier"] = {
+        "score": verifier.get("score"),
+        "passed": verifier.get("passed"),
+        "completion_score": scores.get("score_a"),
+        "integrity_passed": scores.get("score_b"),
+        "integrity_pass_rate": scores.get("integrity_pass_rate"),
+        "completion_details": scores.get("completion_details"),
+        "integrity_details": scores.get("integrity_details"),
+        "feedback": verifier.get("feedback"),
+        "error": verifier.get("error"),
+    }
+    state["info"] = info
+
+
 class GymAnythingAgentEnv(vf.MultiTurnEnv):
     """verifiers MultiTurnEnv that runs a real reference agent's step()."""
 
@@ -474,6 +501,7 @@ class GymAnythingAgentEnv(vf.MultiTurnEnv):
     async def finalize_reward(self, state: vf.State) -> None:
         """Score with the real verifier while the VM is alive (before close)."""
         await asyncio.to_thread(_finalize_episode, state)
+        _surface_verifier_info(state)
 
     @vf.cleanup(priority=0)
     async def close_env(self, state: vf.State) -> None:
@@ -511,6 +539,17 @@ async def actions_executed(state: vf.State) -> float:
 
 async def parse_errors(state: vf.State) -> float:
     return float(state.get("parse_errors", 0))
+
+
+async def verifier_completion(state: vf.State) -> float:
+    """Checklist completion score (0-100), before the integrity gate is applied."""
+    return float(((state.get("verifier") or {}).get("scores") or {}).get("score_a") or 0.0)
+
+
+async def verifier_integrity(state: vf.State) -> float:
+    """1.0 if every integrity check passed, else 0.0. A 0 here hard-zeros the score
+    even when verifier_completion is high (integrity_threshold is all-or-nothing)."""
+    return 1.0 if ((state.get("verifier") or {}).get("scores") or {}).get("score_b") else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -558,8 +597,16 @@ def build_agent_env(
 
     dataset = Dataset.from_list(rows)
     rubric = vf.Rubric(
-        funcs=[task_reward, verifier_passed, verifier_score, actions_executed, parse_errors],
-        weights=[1.0, 0.0, 0.0, 0.0, 0.0],
+        funcs=[
+            task_reward,
+            verifier_passed,
+            verifier_score,
+            verifier_completion,
+            verifier_integrity,
+            actions_executed,
+            parse_errors,
+        ],
+        weights=[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     )
     return GymAnythingAgentEnv(
         dataset=dataset,


### PR DESCRIPTION
Surfaces the VLM checklist breakdown (per-item verdicts, completion vs integrity, reasoning) into `state["info"]` (always saved) plus `verifier_completion`/`verifier_integrity` metrics, so a 0 is inspectable instead of bare. Logging-only. Bumps cua-world to 0.1.9, pin `gym-anything-cua-v0.1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)