### PR TITLE
cua-world hub: rewrite the README for the public listing

### DIFF
--- a/extras/hubs/prime/cua_world/README.md
+++ b/extras/hubs/prime/cua_world/README.md
@@ -1,123 +1,174 @@
 # cua-world
 
-### Overview
+[![arXiv](https://img.shields.io/badge/arXiv-2604.06126-red.svg?style=for-the-badge)](https://arxiv.org/abs/2604.06126)
+[![Docs](https://img.shields.io/badge/Docs-Read-blue?style=for-the-badge&logo=readthedocs&logoColor=white)](https://cmu-l3.github.io/gym-anything/docs/)
+[![Interactive Paper](https://img.shields.io/badge/Interactive-Paper-purple?style=for-the-badge)](https://cmu-l3.github.io/gym-anything/interactive_paper.html)
+[![GitHub](https://img.shields.io/badge/GitHub-Code-black?style=for-the-badge&logo=github)](https://github.com/cmu-l3/gym-anything)
+
+CUA-World is the benchmark built with
+[Gym-Anything](https://github.com/cmu-l3/gym-anything)
+([paper](https://arxiv.org/abs/2604.06126)): real desktop, web, and mobile
+applications running in full VMs, with the applications selected by their
+economic (GDP) impact. Each rollout boots a real Linux, Windows, or Android
+guest in the cloud. The policy sees screenshots and acts with mouse and
+keyboard, and a checklist-based VLM verifier with task-specific privileged
+information scores the trajectory.
+
+## Overview
+
 - **Environment ID**: `cua-world`
-- **Short description**: The CUA-World benchmark (real desktop, web, and mobile applications in full VMs) as a verifiers environment. Each rollout boots a real Linux, Windows, or Android guest; the policy sees screenshots and acts through a `computer` tool; episodes are scored by each task's real programmatic verifier.
-- **Tags**: `computer-use`, `gui`, `multi-turn`, `vision`, `tool-use`
+- **Scale**: 12,866 tasks across 246 environments (200+ applications, covering all 22 major occupation groups)
+- **Platforms**: Linux (206 environments), Windows (29), Android (11)
+- **Splits**: `train` (10,397), `test` (2,469), `long_horizon` (201, one long-horizon task per application, often hundreds of steps: CUA-World-Long in the paper)
+- **Agent**: a reference agent scaffold (`Qwen3VLAgent`) runs inside the environment; the framework samples your chosen model through it
+- **Scoring**: each task's VLM checklist with integrity checks (the paper's verifier); the task's programmatic `verifier.py` optional
+- **Runtime**: one VM per rollout (QEMU or Android emulator) inside a Modal sandbox; nothing runs on your machine
 
-### How it works
-This package is a declaration over the gym-anything library: the dataset is
-enumerated by `gym_anything.registry` (the benchmark layout contract), the
-rollout logic lives in `gym_anything.integrations.prime_rl.verifiers`, and the
-`load_environment` surface comes from `gym_anything.integrations.prime_rl.hub`. Each
-rollout runs a real reference agent's `step()` verbatim (select it with
-`agent`, exactly like `--agent` locally; default `Qwen3VLAgent`) — the
-framework does the sampling through the agent's `llm_call` seam, so the
-prompts, history handling, and parsing are the agent's own code, identical
-to a local run. With the default `runner="modal"`, the
-VM (QEMU with KVM, or the Android emulator) runs inside a Modal VM Sandbox in
-the cloud, so nothing is needed locally beyond a Modal token. Base disk images
-and checkpoints persist in a Modal Volume, so after the first boot of an
-environment, later rollouts load from checkpoint in a few minutes. With
-`remote_url`, rollouts run on a gym-anything remote cluster (master/worker)
-instead. The reward is the benchmark's own: the task's `post_task` export hook
-runs in the VM and the task's `verifier.py` produces
-`{passed, score, feedback}`, mapped to reward exactly as gym-anything does
-natively (sparse tasks give 0/1, partial/rubric give score/100).
+Example applications: GIMP, Apache OpenOffice, Ardour, Rocket.Chat, Apache
+OFBiz (Linux), Garmin BaseCamp, Epi Info (Windows), QField, Sygic GPS
+(Android).
 
-### Prerequisites
-1. This package. For local development inside the repo, install gym-anything
-   editable first, then this shell without deps (so it resolves the already
-   installed gym-anything instead of the pinned git tag):
-   ```bash
-   uv pip install -e ".[modal,prime-rl,benchmark]"      # from repo root
-   uv pip install -e extras/hubs/prime/cua_world --no-deps
-   ```
-   Consumers install it standalone (`prime env install`, or from the wheel),
-   which pulls `gym-anything[modal,prime-rl,benchmark]` from the pinned tag.
-2. A Modal token (`modal token set ...`) for the default runner.
-3. API keys. There are two distinct roles:
-   - **Grader**: with this package's defaults every episode is judged by a
-     VLM checklist (`verifier_mode="vlm_checklist"`) using gemini-3.5-flash,
-     so `GEMINI_API_KEY` must be set even when your policy is not gemini.
-     Without it, rollouts still run (and bill Modal time) but scoring fails
-     at the end. Change the grader with `vlm_model`, `vlm_base_url`, and
-     `vlm_api_key_var`.
-   - **Policy**: the key for whatever OpenAI-compatible endpoint serves the
-     model under evaluation (the `-b` and `-k` flags), for example
-     `PRIME_API_KEY` for Prime inference.
-4. Some environments need a one-time host-side asset fetch
-   (`<env>/scripts/fetch_data.sh` or `download_apk.sh`); envs with
-   `MANUAL_DOWNLOAD.md` need manually supplied assets. Tasks in those
-   environments fail for a fresh install until the assets are supplied.
+## Install
 
-### Quickstart
-A single-task validation run (one rollout, one VM):
 ```bash
-export GEMINI_API_KEY=...   # grader key, see Prerequisites
-export PRIME_API_KEY=...    # policy endpoint key
-vf-eval cua-world -m google/gemini-3.5-flash \
-  -b https://api.pinference.ai/api/v1 -k PRIME_API_KEY \
-  -n 1 -r 1 \
-  -a '{"env_names": ["gimp_env"], "task_ids": ["horizontal_mirror"], "max_turns": 10}'
+prime env install pranjal2041/cua-world
 ```
 
-### Evaluating a split (example: long-horizon with gemini)
-`split` selects any named split from the benchmark's `splits/` files
-(`train`, `test`, `long_horizon`, or `all`). The `long_horizon` split is one
-long-horizon task per application, 201 tasks total. Running gemini as the
-policy on Google's OpenAI-compatible endpoint means one key covers both the
-policy and the grader:
+## Run
+
+The default configuration runs one GIMP task end to end:
+
+```bash
+prime eval run pranjal2041/cua-world -n 1 -r 1
+```
+
+Pick the policy with `-m` as usual. Select tasks, applications, or a split
+with `-a`:
+
+```bash
+prime eval run pranjal2041/cua-world -m google/gemini-3-flash-preview -n 10 -r 1 \
+  -a '{"env_names": "all", "split": "long_horizon", "max_turns": 15}'
+```
+
+For prime-rl training, reference the environment by id and forward the same
+arguments:
+
+```toml
+[[orchestrator.train.env]]
+id = "cua-world"
+args = { env_names = ["gimp_env_all_fast"], split = "train", max_turns = 15 }
+```
+
+Because the agent rebuilds a windowed prompt each turn, use
+`trajectory_strategy = "branching"` when training.
+
+### Credentials
+
+Two secrets are required (on the hub they live in this environment's Secrets
+tab, for local runs export them):
+
+- `GEMINI_API_KEY`: the grader. Every episode is judged by a VLM checklist
+  (gemini-3.5-flash by default). Without it, rollouts still run and bill VM
+  time but score 0 with an error recorded.
+- `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`: the VMs run in Modal sandboxes
+  under this account (locally, `modal token set ...` works too).
+
+Running locally with `vf-eval` additionally needs a key for the policy
+endpoint, passed with `-b`/`-k`:
+
 ```bash
 vf-eval cua-world -m gemini-3.5-flash \
   -b https://generativelanguage.googleapis.com/v1beta/openai/ -k GEMINI_API_KEY \
-  -n 10 -r 1 -c 2 \
-  -a '{"env_names": "all", "split": "long_horizon", "max_turns": 15}'
+  -n 1 -r 1 -a '{"task_ids": ["add_border"]}'
 ```
-Start with a small `-n` (it caps the number of tasks). The first rollout in
-each new environment pays a one-time provisioning boot (minutes to tens of
-minutes) before its checkpoint makes later rollouts fast, and `-c` bounds how
-many VMs run (and bill) at once. Narrow `env_names` to a list to stay inside
-specific applications.
 
-The default agent scaffold (`Qwen3VLAgent`) is model-agnostic and is what the
-recorded gemini baselines used. Add `"agent": "GeminiQwen3Agent"` to the `-a`
-JSON to use the gemini-tuned variant of the same loop (screenshots resized to
-the display resolution, coordinates scaled from it).
+## Environment arguments
 
-### Environment Arguments
-| Arg | Type | Default | Description |
-| --- | ---- | ------- | ----------- |
-| `env_names` | str or list | `"gimp_env"` | Benchmark environment folder name(s), or `"all"` for every environment |
-| `split` | str | `"all"` | Task split (`all`, `train`, `test`, or a named split) |
-| `surface` | str | `"raw"` | `"raw"` or `"verified"` task surface |
-| `task_ids` | list | None | Optional whitelist of task ids |
-| `max_examples` | int | None | Cap dataset rows |
-| `seed` | int | 0 | Reset seed carried in each dataset row |
-| `runner` | str | `"modal"` | gym-anything runner; `qemu_native`/`docker`/`avd_native` run locally, None auto-selects |
-| `remote_url` | str | None | Run on a gym-anything remote cluster instead of in-process (ignores `runner`) |
-| `agent` | str | `"Qwen3VLAgent"` | Reference agent class name from `agents/agents/`, exactly like `--agent` locally (e.g. `GeminiQwen3Agent` for the gemini-tuned scaffold) |
-| `agent_args` | dict | `{"model": "gemini-3.5-flash", "temperature": 1.0}` | The agent's own args dict, exactly like `--agent_args` |
-| `max_turns` | int | 15 | Model-turn budget per rollout |
-| `use_cache` | bool | True | Reuse/create gym-anything checkpoints |
-| `cache_level` | str | `"post_start"` | Checkpoint level |
-| `use_savevm` | bool | False | Full VM-state snapshots (QEMU Linux guests) |
-| `verifier_mode` | str | `"vlm_checklist"` | Task success mode. This package defaults to VLM-checklist grading; set None to use each task's own programmatic verifier |
-| `vlm_backend` / `vlm_model` / `vlm_base_url` | str | `"local"` / `"gemini-3.5-flash"` / Google's OpenAI endpoint | VLM grader config for `verifier_mode="vlm_checklist"` |
-| `vlm_api_key_var` | str | `"GEMINI_API_KEY"` | Env var name holding the VLM grader key (required with the defaults, see Prerequisites) |
+The ones most runs touch:
 
-### Metrics
+| Argument | Default | Description |
+| --- | --- | --- |
+| `env_names` | `"gimp_env_all_fast"` | Application environment name(s), or `"all"` |
+| `split` | `"all"` | `train`, `test`, `long_horizon`, or `all` |
+| `task_ids` | `None` | Optional task allowlist within the selected environments |
+| `max_turns` | `15` | Model-turn budget per rollout |
+| `agent` | `"Qwen3VLAgent"` | Reference agent scaffold (e.g. `GeminiQwen3Agent` for the gemini-tuned variant) |
+| `agent_args` | `{"model": "gemini-3.5-flash", "temperature": 1.0}` | The agent's own arguments |
+
+Advanced (defaults are right for almost everyone):
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `verifier_mode` | `"vlm_checklist"` | Set `None` to use each task's programmatic `verifier.py` instead |
+| `vlm_model` / `vlm_base_url` / `vlm_api_key_var` | gemini-3.5-flash on Google's endpoint | Change the grader model |
+| `runner` | `"modal"` | `qemu_native` / `docker` / `avd_native` run VMs locally instead |
+| `remote_url` | `None` | Run rollouts on a gym-anything remote cluster |
+| `use_cache` / `cache_level` / `use_savevm` | `True` / `"post_start"` / `False` | VM checkpoint behavior |
+| `surface` | `"raw"` | `"raw"` or `"verified"` task surface |
+| `seed` / `max_examples` | `0` / `None` | Reset seed, dataset row cap |
+
+## Scoring and metrics
+
+Each task ships a `vlm_checklist.json`: weighted completion items plus
+integrity checks, written with privileged information from the task's own
+setup (ground truth the agent never sees). The judge scores every item with
+pass, partial, or fail. Failing any integrity item zeroes the score,
+following the paper.
+
 | Metric | Weight | Meaning |
-| ------ | ------ | ------- |
-| `task_reward` | 1.0 | The benchmark's reward from the real verifier |
-| `verifier_passed` | 0.0 | 1.0 if the verifier passed |
-| `verifier_score` | 0.0 | Raw verifier score (0-100) |
-| `actions_executed` | 0.0 | Low-level actions executed in the VM |
-| `parse_errors` | 0.0 | Malformed/missing tool calls |
+| --- | --- | --- |
+| `task_reward` | 1.0 | Final reward (0 to 1) |
+| `verifier_score` | 0.0 | Final checklist score (0-100) after the integrity gate |
+| `verifier_completion` | 0.0 | Checklist score (0-100) before the integrity gate |
+| `verifier_integrity` | 0.0 | 1.0 if every integrity check passed |
+| `verifier_passed` | 0.0 | 1.0 on a perfect, integrity-clean checklist |
+| `actions_executed` / `parse_errors` | 0.0 | Actions executed in the VM, malformed tool calls |
 
-### Concurrency and cost
-One rollout = one VM (one Modal sandbox, ~5 CPU / 12 GB). Set eval
-concurrency (`-c`) to the number of simultaneous VMs you are willing to
-pay for. First boot of a new environment provisions it (installs the app;
-minutes to tens of minutes) and saves a checkpoint to the shared Modal
-volume; subsequent rollouts boot from the checkpoint.
+Every saved sample carries the full verdict in `info.verifier` (per-item
+verdicts with the judge's evidence, sub-scores, overall reasoning) and the
+complete multi-turn trajectory (every screenshot and action). Scoring runs
+while the VM is still alive. A rollout whose grading fails is recorded with
+reward 0 and the error in `info.verifier.error` instead of aborting.
+
+## Cost
+
+One rollout is one VM (about 5 CPU / 12 GB, billed on your Modal account).
+Concurrency (`-c`) bounds how many VMs run at once. The first rollout in a
+new environment pays a one-time provisioning boot (minutes to tens of
+minutes) and saves a checkpoint to a shared Modal volume, after which
+rollouts start in a few minutes. A few environments need a one-time asset
+fetch (`<env>/scripts/fetch_data.sh`, or `MANUAL_DOWNLOAD.md` for manual
+assets) before their tasks pass.
+
+## Reference results
+
+From the paper (test split, Gemini 3 Flash as judge):
+
+| Model | Avg. score | Pass rate |
+| --- | ---: | ---: |
+| Gemini 3 Flash | 50.1 | 22.6% |
+| Kimi-K 2.5 | 37.1 | 12.8% |
+| Qwen3-VL-2B | 12.7 | 1.6% |
+
+On `long_horizon` the strongest model reaches 7.5% pass rate at a 500-step
+budget, and 27.5% (GPT-5.4) at 2,000 steps.
+
+## How it works
+
+This package is a thin declaration over the gym-anything library. Each
+rollout runs the reference agent's `step()` verbatim, and the framework
+samples the model through the agent's `llm_call` seam, so prompts, history
+handling, and parsing are identical to a local run. Disk images and
+checkpoints persist in a Modal volume across rollouts. See the
+[hubs documentation](https://cmu-l3.github.io/gym-anything/docs/extras/hubs/)
+for the full design.
+
+## Local development
+
+Inside the gym-anything repo, install gym-anything editable first, then this
+shell without deps (so it resolves your checkout instead of the pinned tag):
+
+```bash
+uv pip install -e ".[modal,prime-rl,benchmark]"      # from repo root
+uv pip install -e extras/hubs/prime/cua_world --no-deps
+```

--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.9"
+version = "0.1.10"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Terminal-bench-2 style structure, prime-native Run section, badges, real inventory numbers from the registry, Credentials (incl. Modal token), common-vs-advanced args split, updated metrics + failure semantics, paper reference results. Bump to 0.1.10. Package-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)