### PR TITLE
prime-rl: record boot failures as has_error samples, not eval crashes

### DIFF
--- a/extras/hubs/prime/cua_world/pyproject.toml
+++ b/extras/hubs/prime/cua_world/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cua-world"
-version = "0.1.10"
+version = "0.1.11"
 description = "CUA-World computer-use benchmark as a verifiers environment: real desktop/mobile apps in cloud VMs (ModalRunner), scored by real per-task verifiers"
 requires-python = ">=3.10"
 dependencies = [
@@ -19,7 +19,7 @@ dependencies = [
     # registry's runtime deps (litellm etc.) install even if the prime-rl extra
     # resolution ever regresses; the tag must post-date the prime_rl subpackage
     # reorg and the prime-rl-pulls-agents fix.
-    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.6",
+    "gym-anything[modal,prime-rl,benchmark,agents] @ git+https://github.com/cmu-l3/gym-anything@gym-anything-cua-v0.1.7",
 ]
 tags = ["computer-use", "gui", "multi-turn", "vision", "tool-use", "multimodal", "real-world", "train", "eval"]
 

--- a/src/gym_anything/integrations/prime_rl/verifiers.py
+++ b/src/gym_anything/integrations/prime_rl/verifiers.py
@@ -375,7 +375,18 @@ class GymAnythingAgentEnv(vf.MultiTurnEnv):
     async def setup_state(self, state: vf.State) -> None:
         info = state.get("info", {})
         task_description = _task_text(state.get("prompt"))
-        env, obs = await asyncio.to_thread(self._boot, dict(info))
+        try:
+            env, obs = await asyncio.to_thread(self._boot, dict(info))
+        except Exception as e:
+            # Record the real cause for scoring/logging first, then hand the
+            # framework a vf.Error: the rollout loop catches only vf.Error and
+            # records the rollout as an aborted has_error sample, so one failed
+            # boot (missing Modal credentials, provisioning failure) does not
+            # crash the whole eval or training batch.
+            state["episode_reward"] = 0.0
+            state["verifier"] = {"error": f"environment boot failed: {e}"}
+            state["boot_error"] = traceback.format_exc()[-2000:]
+            raise vf.SandboxError(f"environment boot failed: {e}") from e
         state["ga_env"] = env
         state["actions_executed"] = 0
         state["parse_errors"] = 0

--- a/tests/test_prime_rl_integration.py
+++ b/tests/test_prime_rl_integration.py
@@ -223,6 +223,31 @@ class VerifiersAdapterTests(unittest.TestCase):
         self.assertEqual(state["episode_reward"], 0.0)
         self.assertIn("error", state["verifier"])
 
+    def test_setup_state_boot_failure_aborts_as_vf_error(self) -> None:
+        import asyncio
+
+        import verifiers as vf
+
+        from gym_anything.integrations.prime_rl.verifiers import build_agent_env
+
+        rows = [
+            {
+                "prompt": [{"role": "user", "content": "x"}],
+                "info": {"env_dir": "/nonexistent", "env_name": "e", "task_id": "t", "seed": 0},
+                "task": "e/t",
+            }
+        ]
+        env = build_agent_env(rows, agent="Qwen3VLAgent", runner=None, env_id="t")
+        state = {"info": dict(rows[0]["info"]), "prompt": rows[0]["prompt"]}
+        # The rollout loop catches only vf.Error: a boot failure must surface
+        # as one (recorded as an aborted has_error sample), never as the raw
+        # exception, which would crash the whole eval.
+        with self.assertRaises(vf.Error):
+            asyncio.run(env.setup_state(state))
+        self.assertEqual(state["episode_reward"], 0.0)
+        self.assertIn("boot failed", state["verifier"]["error"])
+        self.assertIn("boot_error", state)
+
     def test_build_agent_env_constructs_environment(self) -> None:
         import verifiers as vf
 


### PR DESCRIPTION
The hub's new Quality Scan runs vf-eval without env secrets; a raw Modal AuthError from VM boot crashed the whole eval (verifiers catches only `vf.Error` from `setup_state`). Wrap boot failures in `vf.SandboxError` after stashing the real cause, so one failed boot becomes a recorded `has_error` sample. Verified: credential-less vf-eval exits 0 with `SandboxError -> AuthError` recorded. Bumps cua-world to 0.1.11, pin `gym-anything-cua-v0.1.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)