### PR TITLE
Native computer-use agents: Gemini dual-vocabulary rework + GPT-5.4 agent

### DIFF
--- a/agents/agents/__init__.py
+++ b/agents/agents/__init__.py
@@ -8,6 +8,7 @@ from .claude_gemini_qwen3 import GeminiQwen3Agent
 from .claude_gemini_qwen3_audit import GeminiQwen3AuditAgent
 from .claude_gemini import Gemini3Agent
 from .gemini_computer_use import GeminiComputerUseAgent
+from .gpt54_computer_use import GPT54ComputerUseAgent
 from .kimi import KimiAzureAgent
 from .kimi_distill import KimiDistillAgent
 from .qwen3vl_audit import Qwen3VLAuditAgent
@@ -17,6 +18,7 @@ __all__ = [
     "ClaudeFixedAgent",
     "Gemini3Agent",
     "GeminiComputerUseAgent",
+    "GPT54ComputerUseAgent",
     "GeminiQwen3Agent",
     "GeminiQwen3AuditAgent",
     "KimiAzureAgent",

--- a/agents/agents/gemini_computer_use.py
+++ b/agents/agents/gemini_computer_use.py
@@ -1,8 +1,21 @@
 """Gemini Computer Use agent.
 
-Uses Google's *official* Computer Use tool (`types.ComputerUse`) with
-`gemini-3-flash-preview` (the only Flash model that supports Computer Use as of
-2026-06; `gemini-3.5-flash` returns 400 "computer use capabilities" access error).
+Uses Google's official Computer Use tool (`types.ComputerUse`) and supports
+both current model generations:
+
+- `gemini-3-flash-preview` / `gemini-2.5-computer-use-preview*` emit the
+  legacy action set (click_at, type_text_at, key_combination, scroll_at, ...)
+  and are browser-environment models.
+- `gemini-3.5-flash` emits the newer action set (click, type, hotkey,
+  press_key, scroll, take_screenshot, ...) and supports
+  ENVIRONMENT_DESKTOP (google-genai >= 2.x), which is what this harness
+  actually shows the model.
+
+The translator dispatches on the action *name*, so both vocabularies work
+regardless of which model produced them. Unknown actions are never silently
+swallowed: they are logged, recorded in the transcript, reported back to the
+model as an error in the next function response, and after
+`_MAX_CONSECUTIVE_UNSUPPORTED` in a row the episode is marked done.
 
 Design choices:
 - **Full, untruncated history.** Every turn we append the model's content and a
@@ -10,12 +23,15 @@ Design choices:
   resend the whole list. The official docs show exactly this append-only loop; it
   also keeps the prefix stable so Gemini's implicit context caching is reused. We
   deliberately do NOT compact per turn.
-- One Gemini call per env step. The model returns a single predefined UI action
-  (click_at / type_text_at / key_combination / scroll / drag / ...); we translate
-  it to the env's low-level action dicts (mouse pixel coords in 1920x1080,
-  keyboard text/keys). Gemini coordinates are normalized 0-999 over the screenshot.
+- One Gemini call per env step. The model returns a single predefined UI action;
+  we translate it to the env's low-level action dicts (mouse pixel coords at the
+  native resolution, keyboard text/keys). Gemini coordinates are normalized
+  0-999 over the screenshot.
+- Browser-navigation actions (open_web_browser, search, navigate, ...) are
+  excluded via `excluded_predefined_functions` instead of being begged away in
+  the system prompt.
 - Completion is signalled by the model returning no function_call (a plain text
-  answer) -> we mark done.
+  answer): we mark done.
 """
 import json
 import os
@@ -33,14 +49,13 @@ load_dotenv()
 
 SYSTEM_INSTRUCTION = (
     "You are operating a single desktop application that is ALREADY OPEN and fills "
-    "the screen (1920x1080). Do not open a web browser, navigate to URLs, or use "
-    "search — interact directly with what is on screen using clicks, typing, and "
+    "the screen. Interact directly with what is on screen using clicks, typing, and "
     "keyboard shortcuts via the computer tool. Look carefully at each screenshot "
     "before acting. When the task is fully complete, stop calling the tool and "
     "reply with a short confirmation instead."
 )
 
-# Gemini key-combination names -> env (X11 keysym-ish) names used by the env layer.
+# Gemini key names -> env (X11 keysym-ish) names used by the env layer.
 _KEYMAP = {
     "control": "ctrl", "ctrl": "ctrl", "alt": "alt", "option": "alt",
     "shift": "shift", "meta": "super", "cmd": "super", "command": "super",
@@ -50,6 +65,21 @@ _KEYMAP = {
     "up": "Up", "down": "Down", "left": "Left", "right": "Right",
     "home": "Home", "end": "End", "pageup": "Prior", "pagedown": "Next",
 }
+
+# Models that emit the legacy (browser-only) action vocabulary.
+_LEGACY_MODEL_PREFIXES = ("gemini-2.5-computer-use", "gemini-3-flash")
+
+# Browser-navigation actions this harness can never execute (single desktop
+# app, no browser chrome). Excluded per vocabulary so the model cannot emit
+# them at all.
+_LEGACY_BROWSER_FUNCTIONS = ["open_web_browser", "search", "navigate", "go_back", "go_forward"]
+_NEW_BROWSER_FUNCTIONS = ["navigate", "go_back", "go_forward"]
+
+_MAX_CONSECUTIVE_UNSUPPORTED = 3
+
+
+def _uses_legacy_actions(model: str) -> bool:
+    return model.startswith(_LEGACY_MODEL_PREFIXES)
 
 
 class GeminiComputerUseAgent(BaseAgent):
@@ -70,13 +100,25 @@ class GeminiComputerUseAgent(BaseAgent):
         self.pending_name = None    # name of the function_call awaiting a screenshot
         self.pending_id = None
         self.pending_safety = False
+        self.pending_error = None   # error text to report for the previous action
+        self.consecutive_unsupported = 0
+        self._last_unsupported = False
         self.transcript = []        # human-readable record for inspection
 
         self.setup_custom_logger()
 
+        self.legacy_actions = _uses_legacy_actions(self.model)
+        self.environment = self._resolve_environment()
+        excluded = self.agent_args.get("excluded_functions")
+        if excluded is None:
+            excluded = _LEGACY_BROWSER_FUNCTIONS if self.legacy_actions else _NEW_BROWSER_FUNCTIONS
+
         self.client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
         self.tool = types.Tool(
-            computer_use=types.ComputerUse(environment=types.Environment.ENVIRONMENT_BROWSER)
+            computer_use=types.ComputerUse(
+                environment=self.environment,
+                excluded_predefined_functions=list(excluded),
+            )
         )
         self.config = types.GenerateContentConfig(
             tools=[self.tool],
@@ -90,6 +132,30 @@ class GeminiComputerUseAgent(BaseAgent):
                 thinking_level=self.decoding_params.get("thinking_level", "high"),
             ),
         )
+
+    def _resolve_environment(self):
+        """Pick the ComputerUse environment.
+
+        Legacy models are browser-only. Newer models default to
+        ENVIRONMENT_DESKTOP, which is what this harness actually shows the
+        model, falling back to browser (with a warning) when the installed
+        google-genai predates the desktop enum. Override with
+        agent_args["environment"] = "browser" | "desktop" | "mobile".
+        """
+        requested = self.agent_args.get("environment")
+        if requested is None:
+            requested = "browser" if self.legacy_actions else "desktop"
+        enum_name = f"ENVIRONMENT_{requested.upper()}"
+        env = getattr(types.Environment, enum_name, None)
+        if env is None:
+            print(f"[gemini-cu] google-genai has no {enum_name} (SDK too old?); "
+                  "falling back to ENVIRONMENT_BROWSER")
+            return types.Environment.ENVIRONMENT_BROWSER
+        return env
+
+    @property
+    def _is_browser_env(self):
+        return self.environment == types.Environment.ENVIRONMENT_BROWSER
 
     # ---- bookkeeping (mirrors the other agents) ---------------------------
     def setup_custom_logger(self):
@@ -127,12 +193,19 @@ class GeminiComputerUseAgent(BaseAgent):
                 types.Part.from_bytes(data=shot, mime_type="image/png"),
             ]))
         else:
-            resp = {"url": "app://gridsmith"}
+            resp = {}
+            if self._is_browser_env:
+                # The browser protocol expects a current-URL field; a desktop
+                # app has none, so report a stable placeholder.
+                resp["url"] = f"app://{self.agent_args.get('task_name', 'desktop')}"
+            if self.pending_error:
+                resp["error"] = self.pending_error
             if self.pending_safety:
                 resp["safety_acknowledgement"] = "true"
             fr = self._function_response(self.pending_name, self.pending_id, resp, shot)
             self.contents.append(types.Content(role="user", parts=[types.Part(function_response=fr)]))
             self.pending_safety = False
+            self.pending_error = None
 
         try:
             response = self.client.models.generate_content(
@@ -177,24 +250,82 @@ class GeminiComputerUseAgent(BaseAgent):
 
         actions = self._translate(fc.name, args)
         self.transcript.append({"step": self.step_idx, "action": fc.name,
-                                "args": {k: v for k, v in args.items() if k != "safety_decision"},
-                                "env_actions": actions, "reasoning": reasoning_text})
+                                "args": {k: v for k, v in args.items()
+                                         if k not in ("safety_decision", "intent")},
+                                "intent": args.get("intent"),
+                                "env_actions": actions,
+                                "error": self.pending_error,
+                                "reasoning": reasoning_text})
         self._dump_transcript()
         if self.verbose:
             print(f"[gemini-cu] step {self.step_idx}: {fc.name}({args}) -> {actions}")
+        if self.consecutive_unsupported >= _MAX_CONSECUTIVE_UNSUPPORTED:
+            print(f"[gemini-cu] {self.consecutive_unsupported} unsupported actions "
+                  "in a row; ending episode")
+            self.done = True
+            self._dump_transcript()
         return [{"tool_id": f"gem_{self.step_idx}", "actions": actions}]
 
     # ---- action translation ----------------------------------------------
+    def _unsupported(self, name, detail):
+        """Loud no-op: warn, report the error back to the model, count it."""
+        self.pending_error = f"Action '{name}' is not supported here: {detail}"
+        self.consecutive_unsupported += 1
+        self._last_unsupported = True
+        print(f"[gemini-cu] UNSUPPORTED action {name}: {detail}")
+        return [{"action": "wait", "time": 0.5}]
+
     def _translate(self, name, args):
         W, H = self.display_resolution
 
         def px(x, y):
             return [int(round(float(x) / 1000.0 * W)), int(round(float(y) / 1000.0 * H))]
 
-        if name == "click_at":
+        self._last_unsupported = False
+        known = self._translate_known(name, args, px)
+        if known is not None:
+            if not self._last_unsupported:
+                self.consecutive_unsupported = 0
+            return known
+
+        if name in ("open_app", "list_apps"):
+            return self._unsupported(name, "mobile-only action; this is a desktop app")
+        if name in _LEGACY_BROWSER_FUNCTIONS or name in _NEW_BROWSER_FUNCTIONS:
+            return self._unsupported(name, "browser navigation is unavailable in a single desktop app")
+        return self._unsupported(name, "unknown predefined function for this harness")
+
+    def _translate_known(self, name, args, px):
+        """Return env actions for a recognized action name, else None.
+
+        Handles BOTH Gemini action vocabularies: legacy (gemini-3-flash-preview,
+        gemini-2.5-computer-use-preview) and current (gemini-3.5-flash).
+        """
+        # --- clicks (legacy: click_at / hover_at; new: click family + move) ---
+        if name in ("click_at", "click"):
             return [{"mouse": {"left_click": px(args["x"], args["y"])}}]
-        if name == "hover_at":
+        if name == "right_click":
+            return [{"mouse": {"right_click": px(args["x"], args["y"])}}]
+        if name == "middle_click":
+            return [{"mouse": {"middle_click": px(args["x"], args["y"])}}]
+        if name == "double_click":
+            return [{"mouse": {"double_click": px(args["x"], args["y"])}}]
+        if name == "triple_click":
+            return [{"mouse": {"triple_click": px(args["x"], args["y"])}}]
+        if name in ("hover_at", "move"):
             return [{"mouse": {"move": px(args["x"], args["y"])}}]
+        if name == "mouse_down":
+            return [{"mouse": {"move": px(args["x"], args["y"])}},
+                    {"mouse": {"buttons": {"left_down": True}}}]
+        if name == "mouse_up":
+            return [{"mouse": {"move": px(args["x"], args["y"])}},
+                    {"mouse": {"buttons": {"left_up": True}}}]
+        if name == "long_press":
+            return [{"mouse": {"move": px(args["x"], args["y"])}},
+                    {"mouse": {"buttons": {"left_down": True}}},
+                    {"action": "wait", "time": float(args.get("seconds", 2))},
+                    {"mouse": {"buttons": {"left_up": True}}}]
+
+        # --- typing (legacy: type_text_at clicks first; new: type at focus) ---
         if name == "type_text_at":
             out = [{"mouse": {"left_click": px(args["x"], args["y"])}}]
             if args.get("clear_before_typing"):
@@ -203,24 +334,67 @@ class GeminiComputerUseAgent(BaseAgent):
             if args.get("press_enter"):
                 out.append({"keyboard": {"keys": ["Return"]}})
             return out
+        if name == "type":
+            out = []
+            if args.get("clear_before_typing"):
+                out.append({"keyboard": {"keys": ["ctrl", "a"]}})
+            out.append({"keyboard": {"text": args.get("text", "")}})
+            if args.get("press_enter"):
+                out.append({"keyboard": {"keys": ["Return"]}})
+            return out
+
+        # --- keys ---
         if name == "key_combination":
             return self._key_combo_actions(str(args.get("keys", "")))
+        if name == "press_key":
+            return self._key_combo_actions(str(args.get("key", "")))
+        if name == "hotkey":
+            keys = args.get("keys", [])
+            if isinstance(keys, str):
+                return self._key_combo_actions(keys)
+            return [{"keyboard": {"keys": [_KEYMAP.get(str(k).lower(), str(k)) for k in keys]}}]
+        if name == "key_down":
+            return [{"keyboard": {"keys_down": [_KEYMAP.get(str(args.get("key", "")).lower(),
+                                                            str(args.get("key", "")))]}}]
+        if name == "key_up":
+            return [{"keyboard": {"keys_up": [_KEYMAP.get(str(args.get("key", "")).lower(),
+                                                          str(args.get("key", "")))]}}]
+
+        # --- scrolling ---
         if name == "scroll_document":
             amt = self._scroll_amount(args.get("direction", "down"), 600)
             return [{"mouse": {"scroll": amt}}]
-        if name == "scroll_at":
-            amt = self._scroll_amount(args.get("direction", "down"), int(args.get("magnitude", 600)))
-            return [{"mouse": {"move": px(args["x"], args["y"])}}, {"mouse": {"scroll": amt}}]
+        if name in ("scroll_at", "scroll"):
+            magnitude = int(args.get("magnitude", args.get("magnitude_in_pixels", 600)) or 600)
+            direction = str(args.get("direction", "down")).lower()
+            if direction in ("left", "right"):
+                return self._unsupported(name, "horizontal scroll is not modeled by the env")
+            amt = self._scroll_amount(direction, magnitude)
+            out = []
+            if "x" in args and "y" in args:
+                out.append({"mouse": {"move": px(args["x"], args["y"])}})
+            out.append({"mouse": {"scroll": amt}})
+            return out
+
+        # --- drags (legacy: destination_x/y; new: end_x/y or destination_x/y) ---
         if name == "drag_and_drop":
-            s = px(args["x"], args["y"])
-            d = px(args["destination_x"], args["destination_y"])
-            return [{"mouse": {"move": s}}, {"mouse": {"buttons": {"left_down": True}}},
-                    {"mouse": {"move": d}}, {"mouse": {"buttons": {"left_up": True}}}]
+            sx = args.get("x", args.get("start_x"))
+            sy = args.get("y", args.get("start_y"))
+            dx = args.get("destination_x", args.get("end_x"))
+            dy = args.get("destination_y", args.get("end_y"))
+            if None in (sx, sy, dx, dy):
+                return self._unsupported(name, f"missing drag coordinates in {sorted(args)}")
+            return [{"mouse": {"left_click_drag": [px(sx, sy), px(dx, dy)]}}]
+
+        # --- waiting / observation ---
         if name == "wait_5_seconds":
             return [{"action": "wait", "time": 5}]
-        # open_web_browser / navigate / search / go_back / go_forward: irrelevant to
-        # a single already-open app -> just re-observe so the loop continues.
-        return [{"action": "wait", "time": 0.5}]
+        if name == "wait":
+            return [{"action": "wait", "time": float(args.get("seconds", 1))}]
+        if name == "take_screenshot":
+            return [{"action": "screenshot"}]
+
+        return None
 
     @staticmethod
     def _scroll_amount(direction, magnitude):
@@ -232,13 +406,13 @@ class GeminiComputerUseAgent(BaseAgent):
         return 0  # left/right scroll not modeled
 
     def _key_combo_actions(self, combo):
-        """Translate a Gemini key_combination into env keyboard actions.
+        """Translate a key combination / single key into env keyboard actions.
 
-        Crucially, a single character (incl. GRIDSMITH's aggregator keys
-        + ~ < > # * & and ordinary letters/digits) is *typed*, not sent as an
-        xdotool keysym — `xdotool key +` is ambiguous/invalid, whereas typing it
-        yields the right JS event.key. Named keys (Enter/Escape/Tab/arrows) and
-        modifier chords (Ctrl+A, Shift+Equals) use xdotool key.
+        A single character (letters, digits, punctuation like + ~ < > # * &) is
+        *typed*, not sent as an xdotool keysym — `xdotool key +` is
+        ambiguous/invalid, whereas typing it yields the right JS event.key.
+        Named keys (Enter/Escape/Tab/arrows) and modifier chords (Ctrl+A,
+        Shift+Equals) use xdotool key.
         """
         c = combo.strip()
         if not c:

--- a/agents/agents/gpt54_computer_use.py
+++ b/agents/agents/gpt54_computer_use.py
@@ -1,0 +1,440 @@
+"""GPT-5.4 Computer Use agent.
+
+Uses the OpenAI Responses API with the native ``computer`` tool so GPT-5.4
+(or GPT-5.5) can directly observe screenshots, reason about the GUI, and
+emit mouse / keyboard actions.
+
+Reference: https://developers.openai.com/api/docs/guides/tools-computer-use
+
+Protocol notes:
+- The tool is declared as ``{"type": "computer"}`` with no parameters; the
+  model works in absolute pixel coordinates of the screenshots it receives,
+  which this harness sends at native resolution (no scaling step).
+- One ``computer_call`` carries a BATCH of actions. We split the batch into
+  one action group per action so the GUI gets time to react between them.
+- Conversation state lives server-side via ``previous_response_id``; each
+  turn sends only the new ``computer_call_output`` (screenshot). Server-side
+  compaction is enabled through ``compaction_threshold`` (default 64k
+  rendered tokens).
+- Mouse actions may carry a ``keys`` array of held modifiers (e.g.
+  shift-click); we wrap the mouse primitives in keys_down/keys_up.
+- The model often opens a turn with a bare screenshot request; we satisfy it
+  from the already-captured frame instead of bouncing through an env step.
+"""
+
+from agents.agents.base import BaseAgent
+from agents.shared.llm_clients import call_gpt54_computer_use, convert_gpt_key
+from PIL import Image
+import base64
+import json
+import os
+import pickle
+from io import BytesIO
+from openai import OpenAI
+
+
+class GPT54ComputerUseAgent(BaseAgent):
+    """GPT-5.4 Computer Use agent using the OpenAI Responses API."""
+
+    # ------------------------------------------------------------------ init
+    def __init__(self, *args, **kwargs):
+        self.agent_args = kwargs.get('agent_args', {})
+        self.model = self.agent_args.get('model', 'gpt-5.4')
+        self.compaction_threshold = self.agent_args.get(
+            'compaction_threshold', 64000
+        )
+        if self.compaction_threshold is not None:
+            self.compaction_threshold = int(self.compaction_threshold)
+
+        self.exp_name = self.agent_args.get('exp_name', 'exp')
+        self.setup_custom_logger()
+
+        self.client = OpenAI(
+            api_key=self.agent_args.get('api_key', os.getenv("OPENAI_API_KEY")),
+            base_url=self.agent_args.get('base_url'),
+        )
+
+        # Agent state
+        self.done = False
+        self.step_idx = -1
+        self.previous_response_id = None
+        self.last_computer_call = None   # most-recent computer_call item
+
+        # Trajectory / artifact storage
+        self.responses_metadata = []
+        self.action_history = []
+
+        self.debug = kwargs.get('debug', False)
+        self.verbose = kwargs.get('verbose', False)
+
+    def setup_custom_logger(self):
+        task_name = self.agent_args.get('task_name', 'task')
+        self.save_folder_custom = (
+            f'all_runs/{self.exp_name}/{self.model}/{task_name}'
+        )
+        for run_number in range(0, 1000):
+            candidate = f'{self.save_folder_custom}/run_{run_number}'
+            if not os.path.exists(candidate):
+                self.save_folder_custom = candidate
+                break
+        os.makedirs(self.save_folder_custom, exist_ok=False)
+
+    def save_observation(self, observation):
+        Image.open(observation['screen']['path']).save(
+            f'{self.save_folder_custom}/observation_{self.step_idx}.png'
+        )
+
+    # ----------------------------------------------------------- agent init
+    def init(self, task_description, display_resolution, save_path):
+        self.task_description = task_description
+        self.display_resolution = display_resolution
+        self.save_path = save_path
+
+    # -------------------------------------------------------- internal helpers
+
+    def _get_screenshot_b64(self, obs):
+        """Return the current observation screenshot as a base-64 PNG."""
+        image = Image.open(obs['screen']['path'])
+        buffered = BytesIO()
+        image.save(buffered, format="PNG")
+        return base64.b64encode(buffered.getvalue()).decode("utf-8")
+
+    def _get_computer_call(self, response):
+        """Return the first ``computer_call`` item in *response*, or None."""
+        for item in response.output:
+            if item.type == "computer_call":
+                return item
+        return None
+
+    def _is_screenshot_only(self, actions):
+        """True when every action in the batch is a screenshot request."""
+        return len(actions) > 0 and all(a.type == "screenshot" for a in actions)
+
+    def _send_screenshot(self, screenshot_b64):
+        """Send a ``computer_call_output`` screenshot back to the model."""
+        output_item = {
+            "type": "computer_call_output",
+            "call_id": self.last_computer_call.call_id,
+            "output": {
+                "type": "computer_screenshot",
+                "image_url": f"data:image/png;base64,{screenshot_b64}",
+                # Docs: "prefer detail: 'original' on screenshot inputs" —
+                # preserves full resolution and improves click accuracy.
+                "detail": "original",
+            },
+        }
+
+        # Acknowledge pending safety checks when the API returns them
+        pending = getattr(self.last_computer_call,
+                          'pending_safety_checks', None)
+        if pending:
+            output_item["acknowledged_safety_checks"] = [
+                check.id for check in pending
+            ]
+
+        response = call_gpt54_computer_use(
+            self.client,
+            self.model,
+            [{"type": "computer"}],
+            [output_item],
+            previous_response_id=self.previous_response_id,
+            compaction_threshold=self.compaction_threshold,
+        )
+        self.previous_response_id = response.id
+        self._record_response_metadata(response)
+        return response
+
+    def _record_response_metadata(self, response):
+        """Persist lightweight metadata about every API response."""
+        meta = {
+            'id': response.id,
+            'output_types': [item.type for item in response.output],
+        }
+        for item in response.output:
+            if hasattr(item, 'content') and item.content:
+                for part in item.content:
+                    if hasattr(part, 'text'):
+                        meta['text_output'] = part.text
+                        break
+            # Capture reasoning summary when available
+            if item.type == 'reasoning' and hasattr(item, 'summary'):
+                summaries = item.summary
+                if isinstance(summaries, list):
+                    meta['thinking'] = '\n'.join(
+                        s.text for s in summaries if hasattr(s, 'text')
+                    )
+                elif isinstance(summaries, str):
+                    meta['thinking'] = summaries
+        self.responses_metadata.append(meta)
+
+    # ------------------------------------------------------ action serialization
+
+    def _serialize_action(self, action):
+        """Serialize a GPT action object to a JSON-friendly dict with full details."""
+        atype = action.type
+        info = {'type': atype}
+
+        if atype in ("click", "double_click", "triple_click", "move"):
+            info['x'] = int(action.x)
+            info['y'] = int(action.y)
+            if atype == "click":
+                info['button'] = getattr(action, 'button', 'left')
+        elif atype == "scroll":
+            info['x'] = int(action.x)
+            info['y'] = int(action.y)
+            info['scrollX'] = getattr(action, 'scrollX', 0)
+            info['scrollY'] = getattr(action, 'scrollY', 0)
+        elif atype == "keypress":
+            info['keys'] = list(action.keys)
+        elif atype == "type":
+            info['text'] = action.text
+        elif atype == "drag":
+            if hasattr(action, 'path') and action.path:
+                info['path'] = [[int(p.x), int(p.y)] for p in action.path]
+        elif atype == "wait":
+            info['time'] = getattr(action, 'time', 2.0)
+
+        held = getattr(action, 'keys', None)
+        if held and atype != "keypress":
+            info['held_keys'] = list(held)
+
+        return info
+
+    # ------------------------------------------------------ action conversion
+
+    @staticmethod
+    def _held_modifiers(action):
+        """Modifier keys held for the duration of a mouse action (docs: the
+        mouse action's optional ``keys`` array), mapped to env names."""
+        held = getattr(action, 'keys', None)
+        if not held:
+            return []
+        return [convert_gpt_key(k) for k in held]
+
+    def _convert_single_action(self, action):
+        """Convert one GPT action object to a list of gym primitives."""
+        atype = action.type
+
+        if atype == "click":
+            x, y = int(action.x), int(action.y)
+            button = getattr(action, 'button', 'left')
+            if button == 'right':
+                primitives = [{'mouse': {'right_click': [x, y]}}]
+            elif button == 'middle':
+                primitives = [{'mouse': {'middle_click': [x, y]}}]
+            else:
+                primitives = [{'mouse': {'left_click': [x, y]}}]
+
+        elif atype == "double_click":
+            x, y = int(action.x), int(action.y)
+            primitives = [{'mouse': {'double_click': [x, y]}}]
+
+        elif atype == "triple_click":
+            x, y = int(action.x), int(action.y)
+            primitives = [{'mouse': {'triple_click': [x, y]}}]
+
+        elif atype == "scroll":
+            x, y = int(action.x), int(action.y)
+            scroll_x = getattr(action, 'scrollX', 0)
+            scroll_y = getattr(action, 'scrollY', 0)
+            primitives = [{'mouse': {'move': [x, y]}}]
+            if scroll_x:
+                # Runner doesn't support hscroll natively; warn
+                print(f"[GPT54CU] Warning: horizontal scroll "
+                      f"(scrollX={scroll_x}) not supported, ignoring")
+            if scroll_y:
+                primitives.append({'mouse': {'scroll': scroll_y}})
+
+        elif atype == "keypress":
+            keys = [convert_gpt_key(k) for k in action.keys]
+            return [{'keyboard': {'keys': keys}}]
+
+        elif atype == "type":
+            return [{'keyboard': {'text': action.text}}]
+
+        elif atype == "drag":
+            if hasattr(action, 'path') and action.path:
+                points = [(int(p.x), int(p.y)) for p in action.path]
+            else:
+                sx = int(getattr(action, 'startX',
+                                 getattr(action, 'x', 0)))
+                sy = int(getattr(action, 'startY',
+                                 getattr(action, 'y', 0)))
+                ex = int(getattr(action, 'endX', sx))
+                ey = int(getattr(action, 'endY', sy))
+                points = [(sx, sy), (ex, ey)]
+            primitives = [
+                {'mouse': {'move': list(points[0])}},
+                {'mouse': {'buttons': {'left_down': True}}},
+            ]
+            for pt in points[1:]:
+                primitives.append({'mouse': {'move': list(pt)}})
+            primitives.append({'mouse': {'buttons': {'left_up': True}}})
+
+        elif atype == "move":
+            x, y = int(action.x), int(action.y)
+            primitives = [{'mouse': {'move': [x, y]}}]
+
+        else:
+            # wait / screenshot → handled at the group level
+            return []
+
+        held = self._held_modifiers(action)
+        if held:
+            primitives = (
+                [{'keyboard': {'keys_down': held}}]
+                + primitives
+                + [{'keyboard': {'keys_up': held}}]
+            )
+        return primitives
+
+    def _build_action_groups(self, actions, call_id):
+        """
+        Split a GPT ``computer_call`` action batch into separate action
+        groups that the eval loop can execute one at a time.
+
+        GPT often batches actions like ``[keypress, keypress, wait]``.
+        If we send them all as a single ``env.step()`` call the GUI has
+        no time to react (e.g. a menu must open before the next key).
+
+        Strategy: emit **one action group per GPT action**.  Each group
+        goes through the loop's action processing individually, giving
+        the environment time to update between them.  ``wait`` actions
+        become their own group so the loop sleeps properly.
+        """
+        groups = []
+        for idx, action in enumerate(actions):
+            atype = action.type
+
+            if atype == "screenshot":
+                # no-op inside a batch; the loop captures a frame anyway
+                continue
+
+            if atype == "wait":
+                wait_time = getattr(action, 'time', 2.0)
+                groups.append({
+                    'tool_id': f'{call_id}_w{idx}',
+                    'actions': [{'action': 'wait', 'time': wait_time}],
+                })
+                continue
+
+            gym_primitives = self._convert_single_action(action)
+            if gym_primitives:
+                groups.append({
+                    'tool_id': f'{call_id}_{idx}',
+                    'actions': gym_primitives,
+                })
+
+        return groups
+
+    # ----------------------------------------------------------------- step
+
+    def step(self, obs, action_outputs):
+        self.step_idx += 1
+        self.save_observation(obs)
+
+        screenshot_b64 = self._get_screenshot_b64(obs)
+
+        # ── first turn: send the task description ──
+        if self.step_idx == 0:
+            response = call_gpt54_computer_use(
+                self.client,
+                self.model,
+                [{"type": "computer"}],
+                self.task_description,
+                compaction_threshold=self.compaction_threshold,
+            )
+            self.previous_response_id = response.id
+            self._record_response_metadata(response)
+        else:
+            # ── subsequent turns: return the latest screenshot ──
+            response = self._send_screenshot(screenshot_b64)
+
+        # ── resolve internal screenshot-only loops ──
+        # The model often opens with a bare "screenshot" request.  We satisfy
+        # it immediately (we already have the frame) instead of bouncing back
+        # to the outer loop for a redundant capture.
+        max_internal = 20
+        for _ in range(max_internal):
+            computer_call = self._get_computer_call(response)
+
+            if computer_call is None:
+                # No computer_call → model considers the task complete
+                self.done = True
+                if self.verbose:
+                    for item in response.output:
+                        if hasattr(item, 'content'):
+                            print(f"[GPT54CU] Final: {item.content}")
+                return []
+
+            self.last_computer_call = computer_call
+
+            if self._is_screenshot_only(computer_call.actions):
+                if self.verbose:
+                    print("[GPT54CU] Internal screenshot request – "
+                          "replying with current frame")
+                response = self._send_screenshot(screenshot_b64)
+                continue
+
+            # Got real GUI actions → break out
+            break
+        else:
+            print(f"[GPT54CU] Warning: exceeded {max_internal} internal "
+                  "screenshot loops – marking done")
+            self.done = True
+            return []
+
+        # ── split into per-action groups so the loop executes them one
+        #    at a time, giving the GUI time to react between actions ──
+        action_groups = self._build_action_groups(
+            computer_call.actions, computer_call.call_id)
+
+        if self.verbose:
+            gpt_types = [a.type for a in computer_call.actions]
+            print(f"[GPT54CU] Step {self.step_idx}: "
+                  f"{gpt_types} -> {len(action_groups)} action groups")
+
+        # Record history with full action details
+        self.action_history.append({
+            'step': self.step_idx,
+            'call_id': computer_call.call_id,
+            'gpt_actions': [self._serialize_action(a) for a in computer_call.actions],
+        })
+
+        if not action_groups:
+            self.done = True
+            return []
+        return action_groups
+
+    # --------------------------------------------------------------- finish
+
+    def finish(self, *args, **kwargs):
+        # Action history
+        for dest in (self.save_path, self.save_folder_custom):
+            try:
+                with open(f'{dest}/action_history.json', 'w') as f:
+                    json.dump(self.action_history, f, indent=4)
+            except Exception as e:
+                print(f"Error saving action_history to {dest}: {e}")
+
+        # Response metadata
+        for dest in (self.save_path, self.save_folder_custom):
+            try:
+                with open(f'{dest}/responses_metadata.json', 'w') as f:
+                    json.dump(self.responses_metadata, f, indent=4)
+            except Exception as e:
+                print(f"Error saving responses_metadata to {dest}: {e}")
+
+        # Info dict
+        if 'info' in kwargs:
+            info = kwargs['info']
+            try:
+                with open(
+                    f'{self.save_folder_custom}/info.json', 'w'
+                ) as f:
+                    json.dump(info, f, indent=4)
+            except Exception:
+                with open(
+                    f'{self.save_folder_custom}/info.pkl', 'wb'
+                ) as f:
+                    pickle.dump(info, f)

--- a/agents/shared/llm_clients.py
+++ b/agents/shared/llm_clients.py
@@ -495,3 +495,82 @@ def claude_parse_tool_result(action_json, coord_scale=convert_point_format_claud
 def smart_resize(height, width, factor=32, max_pixels=16 * 16 * 4 * 1280):
     del factor, max_pixels
     return height, width
+
+
+# ---------------------------------------------------------------------------
+# GPT-5.x computer use (OpenAI Responses API, native `computer` tool)
+# ---------------------------------------------------------------------------
+
+# OpenAI's computer-use models emit uppercase key names (ENTER, CTRL,
+# ARROWUP, ...); the env layer wants xdotool-style keysyms (Return, ctrl,
+# Up, ...). Single characters and unknown names pass through lowercased on
+# the letter path so chords like CTRL+A become ctrl+a.
+_GPT_CU_KEYMAP = {
+    "ENTER": "Return", "RETURN": "Return", "TAB": "Tab",
+    "ESC": "Escape", "ESCAPE": "Escape", "BACKSPACE": "BackSpace",
+    "DELETE": "Delete", "DEL": "Delete", "SPACE": "space",
+    "CTRL": "ctrl", "CONTROL": "ctrl", "ALT": "alt", "OPTION": "alt",
+    "SHIFT": "shift", "META": "super", "CMD": "super", "COMMAND": "super",
+    "WIN": "super", "SUPER": "super",
+    "ARROWUP": "Up", "ARROWDOWN": "Down", "ARROWLEFT": "Left",
+    "ARROWRIGHT": "Right", "UP": "Up", "DOWN": "Down", "LEFT": "Left",
+    "RIGHT": "Right",
+    "PAGEUP": "Prior", "PAGEDOWN": "Next", "HOME": "Home", "END": "End",
+    "INSERT": "Insert", "CAPSLOCK": "Caps_Lock", "PRINTSCREEN": "Print",
+}
+
+
+def convert_gpt_key(key):
+    """Map an OpenAI computer-use key name to the env's xdotool-style name."""
+    k = str(key).strip()
+    mapped = _GPT_CU_KEYMAP.get(k.upper())
+    if mapped:
+        return mapped
+    if k.upper().startswith("F") and k[1:].isdigit():
+        return k.upper()  # F1..F12
+    if len(k) == 1 and k.isalpha():
+        return k.lower()
+    return k
+
+
+def call_gpt54_computer_use(
+    client,
+    model,
+    tools,
+    input_items,
+    previous_response_id=None,
+    compaction_threshold=None,
+):
+    """Call the OpenAI Responses API with the native computer tool.
+
+    ``compaction_threshold`` enables server-side compaction
+    (context_management type 'compaction'): when the rendered token count
+    crosses the threshold the server folds prior state into a compaction
+    item. Passed through extra_body so the call works on SDK versions that
+    predate the typed parameter.
+    """
+    kwargs = {
+        "model": model,
+        "tools": tools,
+        "input": input_items,
+        # Surface reasoning summaries so the agent can log the model's
+        # thinking alongside each action.
+        "reasoning": {"summary": "auto"},
+    }
+    if previous_response_id is not None:
+        kwargs["previous_response_id"] = previous_response_id
+    if compaction_threshold is not None:
+        kwargs["extra_body"] = {
+            "context_management": [
+                {"type": "compaction", "compact_threshold": int(compaction_threshold)}
+            ]
+        }
+
+    for attempt in range(5):
+        try:
+            return client.responses.create(**kwargs)
+        except Exception as exc:
+            print(f"Error calling GPT computer use (attempt {attempt + 1}/5): {exc}")
+            time.sleep(2 ** (attempt + 1))
+
+    raise RuntimeError("Failed to get response from GPT computer use after 5 attempts")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,8 @@ agents = [
     "google-genai>=2.10",
     "litellm>=1.52",
     "loguru>=0.7",
-    "openai>=1.0",
+    # 1.66 adds the Responses API, which GPT54ComputerUseAgent requires
+    "openai>=1.66",
     "python-dotenv>=1.0",
     "tqdm>=4.66",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,9 @@ benchmark = [
 agents = [
     "anthropic>=0.50",
     "backoff>=2.2",
-    "google-genai>=1.0",
+    # 2.x adds ENVIRONMENT_DESKTOP/_MOBILE, which GeminiComputerUseAgent
+    # uses for gemini-3.5-flash (older SDKs fall back to browser).
+    "google-genai>=2.10",
     "litellm>=1.52",
     "loguru>=0.7",
     "openai>=1.0",

--- a/tests/test_gemini_computer_use_translation.py
+++ b/tests/test_gemini_computer_use_translation.py
@@ -1,0 +1,157 @@
+"""Offline tests for GeminiComputerUseAgent's action translation.
+
+The agent must handle BOTH Gemini computer-use vocabularies:
+- legacy (gemini-3-flash-preview, gemini-2.5-computer-use-preview*):
+  click_at / type_text_at / key_combination / scroll_at / ...
+- current (gemini-3.5-flash): click / type / hotkey / press_key / scroll / ...
+
+No API access needed: we build the agent without __init__ and call
+_translate directly.
+"""
+import unittest
+
+from agents.agents.gemini_computer_use import (
+    GeminiComputerUseAgent,
+    _uses_legacy_actions,
+)
+
+
+def _bare_agent():
+    agent = object.__new__(GeminiComputerUseAgent)
+    agent.display_resolution = (1000, 1000)  # 0-999 coords map ~1:1 to pixels
+    agent.pending_error = None
+    agent.consecutive_unsupported = 0
+    agent._last_unsupported = False
+    return agent
+
+
+class ModelFamilyTests(unittest.TestCase):
+    def test_legacy_model_detection(self):
+        self.assertTrue(_uses_legacy_actions("gemini-3-flash-preview"))
+        self.assertTrue(_uses_legacy_actions("gemini-2.5-computer-use-preview-10-2025"))
+        self.assertFalse(_uses_legacy_actions("gemini-3.5-flash"))
+
+
+class LegacyVocabularyTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_click_at(self):
+        acts = self.agent._translate("click_at", {"x": 500, "y": 500})
+        self.assertEqual(acts, [{"mouse": {"left_click": [500, 500]}}])
+
+    def test_type_text_at_clicks_then_types(self):
+        acts = self.agent._translate(
+            "type_text_at",
+            {"x": 100, "y": 200, "text": "hi", "clear_before_typing": True, "press_enter": True},
+        )
+        self.assertEqual(acts[0], {"mouse": {"left_click": [100, 200]}})
+        self.assertEqual(acts[1], {"keyboard": {"keys": ["ctrl", "a"]}})
+        self.assertEqual(acts[2], {"keyboard": {"text": "hi"}})
+        self.assertEqual(acts[3], {"keyboard": {"keys": ["Return"]}})
+
+    def test_key_combination_chord(self):
+        acts = self.agent._translate("key_combination", {"keys": "ctrl+s"})
+        self.assertEqual(acts, [{"keyboard": {"keys": ["ctrl", "s"]}}])
+
+    def test_single_char_is_typed_not_keysym(self):
+        acts = self.agent._translate("key_combination", {"keys": "+"})
+        self.assertEqual(acts, [{"keyboard": {"text": "+"}}])
+
+    def test_legacy_drag(self):
+        acts = self.agent._translate(
+            "drag_and_drop", {"x": 0, "y": 0, "destination_x": 999, "destination_y": 999})
+        self.assertEqual(acts, [{"mouse": {"left_click_drag": [[0, 0], [999, 999]]}}])
+
+    def test_wait_5_seconds(self):
+        acts = self.agent._translate("wait_5_seconds", {})
+        self.assertEqual(acts, [{"action": "wait", "time": 5}])
+
+
+class NewVocabularyTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_click_family(self):
+        self.assertEqual(self.agent._translate("click", {"x": 10, "y": 20}),
+                         [{"mouse": {"left_click": [10, 20]}}])
+        self.assertEqual(self.agent._translate("right_click", {"x": 10, "y": 20}),
+                         [{"mouse": {"right_click": [10, 20]}}])
+        self.assertEqual(self.agent._translate("double_click", {"x": 10, "y": 20}),
+                         [{"mouse": {"double_click": [10, 20]}}])
+        self.assertEqual(self.agent._translate("triple_click", {"x": 10, "y": 20}),
+                         [{"mouse": {"triple_click": [10, 20]}}])
+
+    def test_type_at_focus_no_click(self):
+        acts = self.agent._translate("type", {"text": "hello", "press_enter": True})
+        self.assertEqual(acts, [{"keyboard": {"text": "hello"}},
+                                {"keyboard": {"keys": ["Return"]}}])
+
+    def test_press_key_named(self):
+        acts = self.agent._translate("press_key", {"key": "enter"})
+        self.assertEqual(acts, [{"keyboard": {"keys": ["Return"]}}])
+
+    def test_hotkey_list(self):
+        acts = self.agent._translate("hotkey", {"keys": ["ctrl", "shift", "p"]})
+        self.assertEqual(acts, [{"keyboard": {"keys": ["ctrl", "shift", "p"]}}])
+
+    def test_key_down_up(self):
+        self.assertEqual(self.agent._translate("key_down", {"key": "shift"}),
+                         [{"keyboard": {"keys_down": ["shift"]}}])
+        self.assertEqual(self.agent._translate("key_up", {"key": "shift"}),
+                         [{"keyboard": {"keys_up": ["shift"]}}])
+
+    def test_scroll_with_coords_and_magnitude(self):
+        acts = self.agent._translate(
+            "scroll", {"x": 500, "y": 500, "direction": "down", "magnitude_in_pixels": 250})
+        self.assertEqual(acts, [{"mouse": {"move": [500, 500]}},
+                                {"mouse": {"scroll": -250}}])
+
+    def test_new_drag_arg_names(self):
+        acts = self.agent._translate(
+            "drag_and_drop", {"start_x": 1, "start_y": 2, "end_x": 3, "end_y": 4})
+        self.assertEqual(acts, [{"mouse": {"left_click_drag": [[1, 2], [3, 4]]}}])
+
+    def test_take_screenshot(self):
+        self.assertEqual(self.agent._translate("take_screenshot", {}),
+                         [{"action": "screenshot"}])
+
+    def test_wait_seconds(self):
+        self.assertEqual(self.agent._translate("wait", {"seconds": 3}),
+                         [{"action": "wait", "time": 3.0}])
+
+    def test_long_press(self):
+        acts = self.agent._translate("long_press", {"x": 5, "y": 5, "seconds": 2})
+        self.assertEqual(acts[0], {"mouse": {"move": [5, 5]}})
+        self.assertEqual(acts[1], {"mouse": {"buttons": {"left_down": True}}})
+        self.assertEqual(acts[3], {"mouse": {"buttons": {"left_up": True}}})
+
+
+class UnsupportedActionTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_unknown_action_sets_error_and_counts(self):
+        self.agent._translate("teleport", {})
+        self.assertIn("teleport", self.agent.pending_error)
+        self.assertEqual(self.agent.consecutive_unsupported, 1)
+
+    def test_browser_navigation_reports_error(self):
+        self.agent._translate("navigate", {"url": "https://x.test"})
+        self.assertIn("navigate", self.agent.pending_error)
+        self.assertEqual(self.agent.consecutive_unsupported, 1)
+
+    def test_horizontal_scroll_counts_as_unsupported(self):
+        self.agent._translate("scroll", {"x": 1, "y": 1, "direction": "left"})
+        self.assertEqual(self.agent.consecutive_unsupported, 1)
+
+    def test_successful_action_resets_counter(self):
+        self.agent._translate("teleport", {})
+        self.agent._translate("teleport", {})
+        self.assertEqual(self.agent.consecutive_unsupported, 2)
+        self.agent._translate("click", {"x": 1, "y": 1})
+        self.assertEqual(self.agent.consecutive_unsupported, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gpt54_computer_use_translation.py
+++ b/tests/test_gpt54_computer_use_translation.py
@@ -1,0 +1,149 @@
+"""Offline tests for GPT54ComputerUseAgent's action translation.
+
+The OpenAI Responses API computer tool returns batched actions per
+computer_call; each action may carry a `keys` array of held modifiers on
+mouse actions. No API access needed: we build the agent without __init__
+and feed SimpleNamespace action objects.
+"""
+import unittest
+from types import SimpleNamespace as NS
+
+from agents.agents.gpt54_computer_use import GPT54ComputerUseAgent
+from agents.shared.llm_clients import convert_gpt_key
+
+
+def _bare_agent():
+    return object.__new__(GPT54ComputerUseAgent)
+
+
+class ConvertGptKeyTests(unittest.TestCase):
+    def test_named_keys(self):
+        self.assertEqual(convert_gpt_key("ENTER"), "Return")
+        self.assertEqual(convert_gpt_key("CTRL"), "ctrl")
+        self.assertEqual(convert_gpt_key("SHIFT"), "shift")
+        self.assertEqual(convert_gpt_key("META"), "super")
+        self.assertEqual(convert_gpt_key("ARROWUP"), "Up")
+        self.assertEqual(convert_gpt_key("PAGEDOWN"), "Next")
+        self.assertEqual(convert_gpt_key("ESC"), "Escape")
+        self.assertEqual(convert_gpt_key("BACKSPACE"), "BackSpace")
+
+    def test_letters_lowercased_for_chords(self):
+        self.assertEqual(convert_gpt_key("A"), "a")
+        self.assertEqual(convert_gpt_key("a"), "a")
+
+    def test_function_and_unknown_keys(self):
+        self.assertEqual(convert_gpt_key("F5"), "F5")
+        self.assertEqual(convert_gpt_key("f11"), "F11")
+        self.assertEqual(convert_gpt_key("XF86Audio"), "XF86Audio")
+
+
+class ClickTranslationTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_click_buttons(self):
+        a = NS(type="click", x=10, y=20, button="left", keys=None)
+        self.assertEqual(self.agent._convert_single_action(a),
+                         [{'mouse': {'left_click': [10, 20]}}])
+        a = NS(type="click", x=10, y=20, button="right", keys=None)
+        self.assertEqual(self.agent._convert_single_action(a),
+                         [{'mouse': {'right_click': [10, 20]}}])
+        a = NS(type="click", x=10, y=20, button="middle", keys=None)
+        self.assertEqual(self.agent._convert_single_action(a),
+                         [{'mouse': {'middle_click': [10, 20]}}])
+
+    def test_shift_click_wraps_with_held_modifiers(self):
+        a = NS(type="click", x=5, y=6, button="left", keys=["SHIFT"])
+        acts = self.agent._convert_single_action(a)
+        self.assertEqual(acts, [
+            {'keyboard': {'keys_down': ['shift']}},
+            {'mouse': {'left_click': [5, 6]}},
+            {'keyboard': {'keys_up': ['shift']}},
+        ])
+
+    def test_ctrl_scroll_wraps_with_held_modifiers(self):
+        a = NS(type="scroll", x=1, y=2, scrollX=0, scrollY=120, keys=["CTRL"])
+        acts = self.agent._convert_single_action(a)
+        self.assertEqual(acts[0], {'keyboard': {'keys_down': ['ctrl']}})
+        self.assertEqual(acts[-1], {'keyboard': {'keys_up': ['ctrl']}})
+        self.assertIn({'mouse': {'scroll': 120}}, acts)
+
+
+class KeyboardTranslationTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_keypress_maps_key_names(self):
+        a = NS(type="keypress", keys=["CTRL", "A"])
+        self.assertEqual(self.agent._convert_single_action(a),
+                         [{'keyboard': {'keys': ['ctrl', 'a']}}])
+
+    def test_type_text(self):
+        a = NS(type="type", text="hello")
+        self.assertEqual(self.agent._convert_single_action(a),
+                         [{'keyboard': {'text': 'hello'}}])
+
+
+class DragTranslationTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_drag_path(self):
+        a = NS(type="drag", path=[NS(x=0, y=0), NS(x=50, y=50), NS(x=99, y=99)],
+               keys=None)
+        acts = self.agent._convert_single_action(a)
+        self.assertEqual(acts[0], {'mouse': {'move': [0, 0]}})
+        self.assertEqual(acts[1], {'mouse': {'buttons': {'left_down': True}}})
+        self.assertEqual(acts[2], {'mouse': {'move': [50, 50]}})
+        self.assertEqual(acts[3], {'mouse': {'move': [99, 99]}})
+        self.assertEqual(acts[-1], {'mouse': {'buttons': {'left_up': True}}})
+
+
+class ActionGroupTests(unittest.TestCase):
+    def setUp(self):
+        self.agent = _bare_agent()
+
+    def test_batch_splits_into_one_group_per_action(self):
+        actions = [
+            NS(type="click", x=1, y=1, button="left", keys=None),
+            NS(type="keypress", keys=["ENTER"]),
+            NS(type="wait", time=1.5),
+        ]
+        groups = self.agent._build_action_groups(actions, "call_1")
+        self.assertEqual(len(groups), 3)
+        self.assertEqual(groups[0]['tool_id'], "call_1_0")
+        self.assertEqual(groups[2]['actions'],
+                         [{'action': 'wait', 'time': 1.5}])
+
+    def test_screenshot_actions_are_dropped_from_batches(self):
+        actions = [
+            NS(type="screenshot"),
+            NS(type="click", x=1, y=1, button="left", keys=None),
+        ]
+        groups = self.agent._build_action_groups(actions, "call_2")
+        self.assertEqual(len(groups), 1)
+
+    def test_screenshot_only_batch_detection(self):
+        self.assertTrue(self.agent._is_screenshot_only([NS(type="screenshot")]))
+        self.assertFalse(self.agent._is_screenshot_only(
+            [NS(type="screenshot"), NS(type="click", x=1, y=1)]))
+        self.assertFalse(self.agent._is_screenshot_only([]))
+
+
+class SerializationTests(unittest.TestCase):
+    def test_serialize_click_with_held_keys(self):
+        agent = _bare_agent()
+        a = NS(type="click", x=7, y=8, button="left", keys=["SHIFT"])
+        info = agent._serialize_action(a)
+        self.assertEqual(info['type'], 'click')
+        self.assertEqual(info['held_keys'], ['SHIFT'])
+
+    def test_serialize_keypress_has_no_held_keys(self):
+        agent = _bare_agent()
+        info = agent._serialize_action(NS(type="keypress", keys=["CTRL", "C"]))
+        self.assertEqual(info['keys'], ["CTRL", "C"])
+        self.assertNotIn('held_keys', info)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Brings `GeminiComputerUseAgent` in line with Google's current computer-use docs and makes it work with both model generations.

- **Dual action vocabulary.** The translator dispatches on action name and covers both the legacy set emitted by `gemini-3-flash-preview` / `gemini-2.5-computer-use-preview*` (`click_at`, `type_text_at`, `key_combination`, `scroll_at`, ...) and the current `gemini-3.5-flash` set (`click` family, `type`, `press_key`, `key_down`/`key_up`, `hotkey`, `scroll` with magnitude, `drag_and_drop` under either arg naming, `take_screenshot`, `long_press`, `wait`). All mappings target env verbs the runtime supports (including `keys_down`/`keys_up` and native `left_click_drag`).
- **Correct environment declaration.** Newer models default to `ENVIRONMENT_DESKTOP` (what the harness actually shows the model); legacy models stay `ENVIRONMENT_BROWSER`. Overridable via `agent_args["environment"]`, graceful fallback when the installed SDK predates the desktop enum. `google-genai` floored at 2.10 (constraints-ci already pins 2.10.0).
- **No more `app://gridsmith`.** The URL field is only sent in browser environment (where the protocol requires it) and derives from the task name.
- **Browser actions excluded at the API level** via `excluded_predefined_functions` instead of system-prompt instructions.
- **Unsupported actions are loud.** They warn, land in the trajectory transcript, are reported back to the model as an `error` in the next function response, and 3 in a row end the episode instead of silently burning the step budget on 0.5s waits.

## Test plan

- New offline suite `tests/test_gemini_computer_use_translation.py` (21 tests) covers both vocabularies, drag argument variants, single-char vs chord key handling, and the unsupported-action accounting.
- Full suite: 195 passed, 22 skipped.
- Not live-tested against the Gemini API (no key in the dev environment); the new-set argument shapes follow the official docs, with defensive handling where the docs are ambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR: GPT54ComputerUseAgent

New provider-native agent for GPT-5.4/5.5 via the OpenAI Responses API computer tool, ported from a research draft and brought in line with the official guide:

- Tool declared as `{"type": "computer"}`; batched `actions[]` per `computer_call`, split into one action group per action so the GUI reacts between them; internal screenshot-only requests answered from the already-captured frame.
- Held modifier keys on mouse actions (`keys` array) wrap primitives in `keys_down`/`keys_up`, so shift-click and ctrl-scroll work.
- `convert_gpt_key` + `call_gpt54_computer_use` added to `agents/shared/llm_clients.py` (retry idiom, reasoning summaries, server-side compaction via `context_management` compaction entries).
- Screenshot outputs use `detail: "original"` per docs recommendation.
- State via `previous_response_id`; no secrets, no dead code; `openai>=1.66` floor in the agents extra.
- 14 offline translation tests. Not live-tested (no API key in the dev environment).