### PR TITLE
CLI-harness agents: Claude Code and Codex as computer-use agents

### DIFF
--- a/agents/agents/__init__.py
+++ b/agents/agents/__init__.py
@@ -9,13 +9,17 @@ from .claude_gemini_qwen3_audit import GeminiQwen3AuditAgent
 from .claude_gemini import Gemini3Agent
 from .gemini_computer_use import GeminiComputerUseAgent
 from .gpt54_computer_use import GPT54ComputerUseAgent
+from .claude_code import ClaudeCodeAgent
+from .codex_cli import CodexCliAgent
 from .kimi import KimiAzureAgent
 from .kimi_distill import KimiDistillAgent
 from .qwen3vl_audit import Qwen3VLAuditAgent
 
 __all__ = [
     "ClaudeAgent",
+    "ClaudeCodeAgent",
     "ClaudeFixedAgent",
+    "CodexCliAgent",
     "Gemini3Agent",
     "GeminiComputerUseAgent",
     "GPT54ComputerUseAgent",

--- a/agents/agents/claude_code.py
+++ b/agents/agents/claude_code.py
@@ -1,0 +1,45 @@
+"""Claude Code as a gym-anything computer-use agent.
+
+Runs the Claude Code CLI headless inside a throwaway scratch container that can
+only reach the action gateway (and the Anthropic API). See
+``agents/shared/cli_harness.py`` for the shared machinery and the containment
+model.
+"""
+
+from __future__ import annotations
+
+import os
+
+from agents.shared.cli_harness import CliHarnessAgent
+
+
+class ClaudeCodeAgent(CliHarnessAgent):
+    image_tag = "gym-anything-cli-harness-claude:latest"
+    install_block = "RUN npm install -g @anthropic-ai/claude-code"
+
+    def container_env(self) -> dict[str, str]:
+        env: dict[str, str] = {
+            "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
+            # Claude Code needs this to permit bypassPermissions as root in a
+            # container, and we disable telemetry egress.
+            "IS_SANDBOX": "1",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+            "CLAUDE_CONFIG_DIR": "/logs/claude-config",
+        }
+        base_url = os.environ.get("ANTHROPIC_BASE_URL", "")
+        if base_url:
+            env["ANTHROPIC_BASE_URL"] = base_url
+        if self.model:
+            # Strip a provider prefix (harbor-style "anthropic/...") for the
+            # official API; keep the full name behind a custom base URL.
+            env["ANTHROPIC_MODEL"] = self.model if base_url else self.model.split("/")[-1]
+        return env
+
+    def build_cli_command(self) -> str:
+        return (
+            "mkdir -p $CLAUDE_CONFIG_DIR; "
+            'cat /logs/prompt.txt | claude --verbose '
+            "--output-format=stream-json "
+            "--permission-mode=bypassPermissions "
+            "--print"
+        )

--- a/agents/agents/claude_code.py
+++ b/agents/agents/claude_code.py
@@ -1,9 +1,9 @@
 """Claude Code as a gym-anything computer-use agent.
 
-Runs the Claude Code CLI headless inside a throwaway scratch container that can
-only reach the action gateway (and the Anthropic API). See
-``agents/shared/cli_harness.py`` for the shared machinery and the containment
-model.
+Runs the Claude Code CLI headless inside a throwaway, isolated sandbox
+(apptainer or docker; see ``agents/shared/agent_sandbox.py``) that can only
+reach the action gateway and the Anthropic API. See
+``agents/shared/cli_harness.py`` for the shared machinery.
 """
 
 from __future__ import annotations
@@ -14,8 +14,8 @@ from agents.shared.cli_harness import CliHarnessAgent
 
 
 class ClaudeCodeAgent(CliHarnessAgent):
-    image_tag = "gym-anything-cli-harness-claude:latest"
-    install_block = "RUN npm install -g @anthropic-ai/claude-code"
+    sandbox_name = "claude"
+    sandbox_install = "npm install -g @anthropic-ai/claude-code"
 
     def container_env(self) -> dict[str, str]:
         env: dict[str, str] = {

--- a/agents/agents/codex_cli.py
+++ b/agents/agents/codex_cli.py
@@ -27,10 +27,16 @@ class CodexCliAgent(CliHarnessAgent):
         return env
 
     def build_cli_command(self) -> str:
-        model = (self.model or "gpt-5.4").split("/")[-1]
-        # Codex reads the instruction as a positional arg; feed the rendered
-        # prompt file so we don't shell-escape a large multi-line string.
+        model = (self.model or "gpt-5.1").split("/")[-1]
+        # Codex authenticates from $CODEX_HOME/auth.json, not the OPENAI_API_KEY
+        # env var alone; without it codex falls back to ChatGPT-account mode
+        # (gates models and needs a login). Write the API-key auth.json first,
+        # into a writable dir under the bound /logs. Codex reads the instruction
+        # as a positional arg; feed the rendered prompt file so we don't
+        # shell-escape a large multi-line string.
         return (
+            "export CODEX_HOME=/logs/codex-home && mkdir -p $CODEX_HOME && "
+            'printf \'{"OPENAI_API_KEY": "%s"}\' "$OPENAI_API_KEY" > $CODEX_HOME/auth.json && '
             "codex exec "
             "--dangerously-bypass-approvals-and-sandbox "
             "--skip-git-repo-check "

--- a/agents/agents/codex_cli.py
+++ b/agents/agents/codex_cli.py
@@ -1,9 +1,9 @@
 """OpenAI Codex CLI as a gym-anything computer-use agent.
 
-Runs the Codex CLI headless inside a throwaway scratch container that can only
-reach the action gateway (and the OpenAI API). See
-``agents/shared/cli_harness.py`` for the shared machinery and the containment
-model.
+Runs the Codex CLI headless inside a throwaway, isolated sandbox (apptainer or
+docker; see ``agents/shared/agent_sandbox.py``) that can only reach the action
+gateway and the OpenAI API. See ``agents/shared/cli_harness.py`` for the shared
+machinery.
 """
 
 from __future__ import annotations
@@ -14,8 +14,8 @@ from agents.shared.cli_harness import CliHarnessAgent
 
 
 class CodexCliAgent(CliHarnessAgent):
-    image_tag = "gym-anything-cli-harness-codex:latest"
-    install_block = "RUN npm install -g @openai/codex"
+    sandbox_name = "codex"
+    sandbox_install = "npm install -g @openai/codex"
 
     def container_env(self) -> dict[str, str]:
         env: dict[str, str] = {

--- a/agents/agents/codex_cli.py
+++ b/agents/agents/codex_cli.py
@@ -1,0 +1,40 @@
+"""OpenAI Codex CLI as a gym-anything computer-use agent.
+
+Runs the Codex CLI headless inside a throwaway scratch container that can only
+reach the action gateway (and the OpenAI API). See
+``agents/shared/cli_harness.py`` for the shared machinery and the containment
+model.
+"""
+
+from __future__ import annotations
+
+import os
+
+from agents.shared.cli_harness import CliHarnessAgent
+
+
+class CodexCliAgent(CliHarnessAgent):
+    image_tag = "gym-anything-cli-harness-codex:latest"
+    install_block = "RUN npm install -g @openai/codex"
+
+    def container_env(self) -> dict[str, str]:
+        env: dict[str, str] = {
+            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
+        }
+        base_url = os.environ.get("OPENAI_BASE_URL", "")
+        if base_url:
+            env["OPENAI_BASE_URL"] = base_url
+        return env
+
+    def build_cli_command(self) -> str:
+        model = (self.model or "gpt-5.4").split("/")[-1]
+        # Codex reads the instruction as a positional arg; feed the rendered
+        # prompt file so we don't shell-escape a large multi-line string.
+        return (
+            "codex exec "
+            "--dangerously-bypass-approvals-and-sandbox "
+            "--skip-git-repo-check "
+            f"--model {model} "
+            "--json "
+            '-- "$(cat /logs/prompt.txt)"'
+        )

--- a/agents/evaluation/run_single.py
+++ b/agents/evaluation/run_single.py
@@ -372,8 +372,21 @@ def run_single(args: argparse.Namespace) -> int:
     env_step_kwargs = {"wait_between_actions": 0.0} if getattr(args, "fast_io", False) else {}
     post_step_observation_delay = _nonnegative_seconds(args, "post_step_observation_delay")
 
+    autonomous = getattr(agent, "autonomous", False)
+
     try:
-        for _step_i in tqdm(range(max_steps)):
+        if autonomous:
+            # Autonomous agents (external CLI harnesses like Claude Code / Codex)
+            # own the whole episode: the harness drives env.step() through the
+            # action gateway. We kick it off, then fall into the shared
+            # mark_done verification path below, so verifiers/frames/traj.jsonl
+            # stay identical to every other agent. The step loop iterates zero
+            # times in this case.
+            logger.info("Running autonomous agent %s", args.agent)
+            agent.run_episode(env=env, task_description=task_description)
+            obs, _reward, done, info = env.step([], mark_done=True, **env_step_kwargs)
+
+        for _step_i in tqdm(range(0 if autonomous else max_steps)):
             iteration_start = time.perf_counter()
             t0 = time.perf_counter()
             actions = agent.step(obs, action_outputs)

--- a/agents/shared/agent_sandbox.py
+++ b/agents/shared/agent_sandbox.py
@@ -64,8 +64,8 @@ _COMMON_INSTALL = (
 )
 
 
-def _run(args: list[str], timeout: int | None = None) -> subprocess.CompletedProcess:
-    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+def _run(args: list[str], timeout: int | None = None, cwd: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False, cwd=cwd)
 
 
 class AgentSandbox(ABC):
@@ -217,10 +217,12 @@ class ApptainerSandbox(AgentSandbox):
             def_path.write_text(self.definition())
             logger.info("Building apptainer agent sandbox %s", self.sif_path)
             # --fakeroot lets the %post apt/npm installs run rootless (same as
-            # the env ApptainerDirectRunner build path).
+            # the env ApptainerDirectRunner build path). Run from the build dir
+            # so the def's %files source (`act`) resolves relative to it.
             result = _run(
-                ["apptainer", "build", "--fakeroot", str(self.sif_path), str(def_path)],
+                ["apptainer", "build", "--fakeroot", str(self.sif_path), "sandbox.def"],
                 timeout=1800,
+                cwd=str(path),
             )
             if result.returncode != 0:
                 raise RuntimeError(f"apptainer build failed:\n{result.stderr}")

--- a/agents/shared/agent_sandbox.py
+++ b/agents/shared/agent_sandbox.py
@@ -1,0 +1,287 @@
+"""Isolated sandbox for running external CLI coding agents.
+
+The coding CLI (Claude Code, Codex, ...) must run in a lightweight, isolated
+container that has no filesystem or process access to the task env VM, and can
+only reach the host action gateway plus the model provider API. This module
+provides one backend-agnostic protocol (``AgentSandbox``) so the agent code
+never names a container technology, exactly like the env code talks to
+``BaseRunner``.
+
+Backends are auto-selected the way env runners are (an explicit
+``GYM_ANYTHING_AGENT_SANDBOX`` override, then detect what the machine has):
+
+- ``ApptainerSandbox`` — rootless, no daemon. Primary on clusters (Babel).
+- ``DockerSandbox`` — daemon machines; also gets bridge network isolation.
+
+There is deliberately no no-isolation fallback: running a coding CLI with
+permission-bypass flags outside a sandbox is never acceptable, so if neither
+backend is available we raise.
+
+Isolation, stated honestly:
+- File isolation: always. The backend gives the container its own root fs, and
+  the env is a separate VM, so the agent has no filesystem path into the env.
+- Process isolation: always (PID namespace: apptainer instances, docker).
+- Network: docker's bridge additionally blocks any route to the env's ports.
+  Rootless apptainer shares the host network namespace (unavoidable rootless,
+  and outbound is needed for the API + gateway), so the env-port guarantee
+  there softens to "the agent is given only the gateway and never the env's
+  SSH/VNC host, port, or password."
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Backend-agnostic description of the scratch image to run the CLI in."""
+
+    name: str          # cache key, e.g. "claude" / "codex"
+    base_image: str    # docker ref, e.g. "node:22-slim"
+    install: str       # shell that installs the CLI on top of the common base
+    act_script: str    # the `act` gateway-wrapper script, copied to /usr/local/bin
+
+    def digest(self) -> str:
+        raw = f"{self.base_image}\n{self.install}\n{self.act_script}".encode()
+        return hashlib.sha256(raw).hexdigest()[:12]
+
+
+# Common packages layered on top of the base image, shared by all backends.
+_COMMON_INSTALL = (
+    "apt-get update && apt-get install -y --no-install-recommends "
+    "curl ca-certificates python3 procps && rm -rf /var/lib/apt/lists/*"
+)
+
+
+def _run(args: list[str], timeout: int | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, timeout=timeout, check=False)
+
+
+class AgentSandbox(ABC):
+    """One isolated container run: build the image, start it, exec the CLI, stop.
+
+    The CLI's writable scratch (config, ``obs/`` screenshots) lives under the
+    bind-mounted ``/logs`` so it is host-visible and sidesteps rootless
+    permission issues on the container's own root fs.
+    """
+
+    #: Address the gateway should bind to for this backend.
+    gateway_bind_host: str = "127.0.0.1"
+
+    def __init__(self, spec: SandboxSpec, logs_dir: Path):
+        self.spec = spec
+        self.logs_dir = Path(logs_dir)
+
+    def gateway_url(self, port: int) -> str:
+        """URL the container uses to reach the host gateway."""
+        return f"http://{self.gateway_bind_host}:{port}/act"
+
+    @abstractmethod
+    def build(self) -> None:
+        """Build/cache the scratch image (idempotent)."""
+
+    @abstractmethod
+    def start(self, gateway_port: int, gateway_token: str, container_env: dict[str, str]) -> None:
+        """Start the container with the gateway coordinates and API-key env."""
+
+    @abstractmethod
+    def exec(self, command: str, timeout_sec: int) -> subprocess.CompletedProcess:
+        """Run the CLI invocation inside the container, teeing stdout to /logs."""
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Tear the container down (best effort)."""
+
+    # Shared helpers -------------------------------------------------------
+
+    def _prepare_logs(self) -> None:
+        (self.logs_dir / "work").mkdir(parents=True, exist_ok=True)
+        (self.logs_dir / "home").mkdir(parents=True, exist_ok=True)
+
+    def _full_env(self, gateway_port: int, gateway_token: str, container_env: dict[str, str]) -> dict[str, str]:
+        env = {
+            "HOME": "/logs/home",
+            "GATEWAY_URL": self.gateway_url(gateway_port),
+            "GATEWAY_TOKEN": gateway_token,
+        }
+        env.update({k: v for k, v in container_env.items() if v})
+        return env
+
+
+class DockerSandbox(AgentSandbox):
+    gateway_bind_host = "0.0.0.0"  # bridge network reaches the host via host-gateway
+
+    def __init__(self, spec: SandboxSpec, logs_dir: Path):
+        super().__init__(spec, logs_dir)
+        self.image_tag = f"gym-anything-agent-sandbox-{spec.name}:{spec.digest()}"
+        self.container_name = f"gym-agent-{spec.name}-{os.urandom(4).hex()}"
+        self._env: dict[str, str] = {}
+
+    def gateway_url(self, port: int) -> str:
+        return f"http://host.docker.internal:{port}/act"
+
+    def dockerfile(self) -> str:
+        return (
+            f"FROM {self.spec.base_image}\n"
+            f"RUN {_COMMON_INSTALL}\n"
+            f"RUN {self.spec.install}\n"
+            "COPY act /usr/local/bin/act\n"
+            "RUN chmod +x /usr/local/bin/act\n"
+            "RUN mkdir -p /logs/work /logs/home\n"
+            "WORKDIR /logs/work\n"
+        )
+
+    def build(self) -> None:
+        if _run(["docker", "image", "inspect", self.image_tag]).returncode == 0:
+            return
+        with tempfile.TemporaryDirectory() as build_dir:
+            path = Path(build_dir)
+            (path / "act").write_text(self.spec.act_script)
+            (path / "Dockerfile").write_text(self.dockerfile())
+            logger.info("Building docker agent sandbox %s", self.image_tag)
+            result = _run(["docker", "build", "-t", self.image_tag, str(path)], timeout=1800)
+            if result.returncode != 0:
+                raise RuntimeError(f"docker build failed:\n{result.stderr}")
+
+    def start(self, gateway_port: int, gateway_token: str, container_env: dict[str, str]) -> None:
+        self._prepare_logs()
+        self._env = self._full_env(gateway_port, gateway_token, container_env)
+        env_args: list[str] = []
+        for key, value in self._env.items():
+            env_args += ["-e", f"{key}={value}"]
+        args = [
+            "docker", "run", "-d", "--rm", "--name", self.container_name,
+            "--add-host", "host.docker.internal:host-gateway",
+            "-v", f"{self.logs_dir}:/logs",
+            *env_args,
+            self.image_tag, "sleep", "infinity",
+        ]
+        result = _run(args, timeout=120)
+        if result.returncode != 0:
+            raise RuntimeError(f"docker run failed:\n{result.stderr}")
+
+    def exec(self, command: str, timeout_sec: int) -> subprocess.CompletedProcess:
+        wrapped = f"set -o pipefail; ({command}) 2>&1 | tee /logs/cli_stdout.txt"
+        return _run(
+            ["docker", "exec", "-w", "/logs/work", self.container_name, "bash", "-lc", wrapped],
+            timeout=timeout_sec,
+        )
+
+    def stop(self) -> None:
+        _run(["docker", "rm", "-f", self.container_name], timeout=60)
+
+
+class ApptainerSandbox(AgentSandbox):
+    gateway_bind_host = "127.0.0.1"  # shares host net; reaches the host on loopback
+
+    _CACHE_DIR = Path.home() / ".cache" / "gym-anything" / "agent-sandbox"
+
+    def __init__(self, spec: SandboxSpec, logs_dir: Path):
+        super().__init__(spec, logs_dir)
+        self.sif_path = self._CACHE_DIR / f"{spec.name}-{spec.digest()}.sif"
+        self.instance_name = f"gym-agent-{spec.name}-{os.urandom(4).hex()}"
+        self._env_file: Path | None = None
+
+    def definition(self) -> str:
+        return (
+            "Bootstrap: docker\n"
+            f"From: {self.spec.base_image}\n"
+            "\n%files\n"
+            "    act /usr/local/bin/act\n"
+            "\n%post\n"
+            f"    {_COMMON_INSTALL}\n"
+            f"    {self.spec.install}\n"
+            "    chmod +x /usr/local/bin/act\n"
+            "    mkdir -p /logs/work /logs/home\n"
+        )
+
+    def build(self) -> None:
+        if self.sif_path.exists():
+            return
+        self.sif_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as build_dir:
+            path = Path(build_dir)
+            (path / "act").write_text(self.spec.act_script)
+            def_path = path / "sandbox.def"
+            def_path.write_text(self.definition())
+            logger.info("Building apptainer agent sandbox %s", self.sif_path)
+            # --fakeroot lets the %post apt/npm installs run rootless (same as
+            # the env ApptainerDirectRunner build path).
+            result = _run(
+                ["apptainer", "build", "--fakeroot", str(self.sif_path), str(def_path)],
+                timeout=1800,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"apptainer build failed:\n{result.stderr}")
+
+    def start(self, gateway_port: int, gateway_token: str, container_env: dict[str, str]) -> None:
+        self._prepare_logs()
+        env = self._full_env(gateway_port, gateway_token, container_env)
+        self._env_file = self.logs_dir / "sandbox.env"
+        self._env_file.write_text("".join(f"{k}={v}\n" for k, v in env.items()))
+        args = [
+            "apptainer", "instance", "start",
+            "--contain", "--cleanenv", "--writable-tmpfs",
+            "--bind", f"{self.logs_dir}:/logs",
+            str(self.sif_path), self.instance_name,
+        ]
+        result = _run(args, timeout=120)
+        if result.returncode != 0:
+            raise RuntimeError(f"apptainer instance start failed:\n{result.stderr}")
+
+    def exec(self, command: str, timeout_sec: int) -> subprocess.CompletedProcess:
+        wrapped = f"set -o pipefail; ({command}) 2>&1 | tee /logs/cli_stdout.txt"
+        args = [
+            "apptainer", "exec", "--pwd", "/logs/work",
+            "--env-file", str(self._env_file),
+            f"instance://{self.instance_name}", "bash", "-lc", wrapped,
+        ]
+        return _run(args, timeout=timeout_sec)
+
+    def stop(self) -> None:
+        _run(["apptainer", "instance", "stop", self.instance_name], timeout=60)
+
+
+def _apptainer_available() -> bool:
+    return shutil.which("apptainer") is not None
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def select_sandbox(spec: SandboxSpec, logs_dir: Path) -> AgentSandbox:
+    """Pick a sandbox backend: explicit override, else detect. No fallback.
+
+    Precedence mirrors env runner selection: ``GYM_ANYTHING_AGENT_SANDBOX``
+    wins, then apptainer (rootless), then docker.
+    """
+    choice = os.environ.get("GYM_ANYTHING_AGENT_SANDBOX", "").strip().lower()
+    if choice == "apptainer":
+        return ApptainerSandbox(spec, logs_dir)
+    if choice == "docker":
+        return DockerSandbox(spec, logs_dir)
+    if choice:
+        raise ValueError(
+            f"Unknown GYM_ANYTHING_AGENT_SANDBOX={choice!r}; use 'apptainer' or 'docker'"
+        )
+
+    if _apptainer_available():
+        return ApptainerSandbox(spec, logs_dir)
+    if _docker_available():
+        return DockerSandbox(spec, logs_dir)
+    raise RuntimeError(
+        "No agent sandbox backend available: need apptainer (rootless) or docker. "
+        "Refusing to run a coding CLI without isolation."
+    )

--- a/agents/shared/cli_harness.py
+++ b/agents/shared/cli_harness.py
@@ -36,6 +36,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional
 
+from PIL import Image
+
 from agents.shared.agent_sandbox import SandboxSpec, select_sandbox
 from agents.shared.qwen_computer_use import parse_qwen3vl_response
 
@@ -46,9 +48,18 @@ logger = logging.getLogger(__name__)
 # the list here so both the prompt and the gateway agree.
 _TERMINATE_ACTIONS = {"terminate", "done", "finish"}
 
+# The screenshot the CLI's model sees is downscaled to fit this longest side.
+# Coding CLIs (Claude Code, Codex) silently downscale large images before the
+# model sees them and then report pixel coordinates in that reduced space; if
+# we serve full-res frames, every click lands short. So WE control the display
+# size: serve frames at this size, take pixel coords in it, and scale back to
+# the env's native resolution. 1280 keeps the image under model auto-downscale
+# thresholds so what the model sees is 1:1 with what we sent.
+_DISPLAY_MAX_LONG_SIDE = 1280
 
-def _obs_png_b64(obs: dict[str, Any]) -> Optional[str]:
-    """Extract the observation screenshot as a base64 PNG string, or None."""
+
+def _obs_png_bytes(obs: dict[str, Any]) -> Optional[bytes]:
+    """Extract the observation screenshot as raw PNG bytes, or None."""
     if not isinstance(obs, dict):
         return None
     screen = obs.get("screen") or {}
@@ -58,13 +69,16 @@ def _obs_png_b64(obs: dict[str, Any]) -> Optional[str]:
     if image is not None and hasattr(image, "save"):
         buffer = BytesIO()
         image.save(buffer, format="PNG")
-        return base64.b64encode(buffer.getvalue()).decode("ascii")
+        return buffer.getvalue()
     if screen.get("png_b64"):
-        return screen["png_b64"]
+        try:
+            return base64.b64decode(screen["png_b64"])
+        except (ValueError, TypeError):
+            return None
     path = screen.get("path")
     if path and os.path.exists(path):
         with open(path, "rb") as handle:
-            return base64.b64encode(handle.read()).decode("ascii")
+            return handle.read()
     return None
 
 
@@ -86,6 +100,13 @@ class ActionGateway:
     ):
         self.env = env
         self.width, self.height = resolution
+        # Display size the model actually sees; coords come back in this space.
+        scale = min(1.0, _DISPLAY_MAX_LONG_SIDE / max(self.width, self.height))
+        self.display_w = max(1, round(self.width * scale))
+        self.display_h = max(1, round(self.height * scale))
+        # Model (display) pixels -> env (native) pixels.
+        self.ratio_x = self.width / self.display_w
+        self.ratio_y = self.height / self.display_h
         self.max_steps = max_steps
         self.token = token
         self.steps_taken = 0
@@ -93,14 +114,32 @@ class ActionGateway:
         self._server: Optional[ThreadingHTTPServer] = None
         self._thread: Optional[threading.Thread] = None
 
+    def _display_screenshot_b64(self, obs: dict[str, Any]) -> Optional[str]:
+        """Return the observation resized to the display size as a base64 PNG."""
+        raw = _obs_png_bytes(obs)
+        if raw is None:
+            return None
+        try:
+            img = Image.open(BytesIO(raw))
+            if img.size != (self.display_w, self.display_h):
+                img = img.resize((self.display_w, self.display_h))
+            buffer = BytesIO()
+            img.convert("RGB").save(buffer, format="PNG")
+            return base64.b64encode(buffer.getvalue()).decode("ascii")
+        except Exception:
+            # Not a decodable image (e.g. a stub in tests): pass bytes through.
+            return base64.b64encode(raw).decode("ascii")
+
     # --- action translation ------------------------------------------------
 
     def _env_actions_for(self, command: str) -> tuple[list[dict[str, Any]], bool, Optional[str]]:
         """Return (env_actions, is_terminal, error) for a command string.
 
         Reuses ``parse_qwen3vl_response`` (single source of truth for the
-        vocabulary and 0-1000 -> pixel scaling) by wrapping the raw action
-        JSON in the tool-call envelope the parser expects.
+        action vocabulary) by wrapping the raw action JSON in the tool-call
+        envelope the parser expects. The model gives pixel coordinates in the
+        display-sized screenshot it was shown; the parser's ``scale_dims``
+        ratio maps those display pixels back to the env's native resolution.
         """
         try:
             action_json = json.loads(command)
@@ -124,7 +163,7 @@ class ActionGateway:
         parsed = parse_qwen3vl_response(
             synthetic,
             scale_dims=True,
-            scale_dims_ratio=(self.width / 1000.0, self.height / 1000.0),
+            scale_dims_ratio=(self.ratio_x, self.ratio_y),
         )
         meta = parsed["metadata"]
         if meta.get("parse_error"):
@@ -143,7 +182,7 @@ class ActionGateway:
                 "budget_remaining": 0,
                 "done": True,
                 "error": "step budget exhausted",
-                "screenshot_b64": _obs_png_b64(obs),
+                "screenshot_b64": self._display_screenshot_b64(obs),
             }
 
         env_actions, is_terminal, error = self._env_actions_for(command)
@@ -159,7 +198,7 @@ class ActionGateway:
                 "budget_remaining": self.max_steps - self.steps_taken,
                 "done": False,
                 "error": error,
-                "screenshot_b64": _obs_png_b64(obs),
+                "screenshot_b64": self._display_screenshot_b64(obs),
             }
 
         obs, _reward, done, _info = self.env.step(env_actions)
@@ -178,7 +217,7 @@ class ActionGateway:
             "budget_remaining": max(0, self.max_steps - self.steps_taken),
             "done": bool(done) or is_terminal or self.steps_taken >= self.max_steps,
             "error": None,
-            "screenshot_b64": _obs_png_b64(obs),
+            "screenshot_b64": self._display_screenshot_b64(obs),
         }
 
     # --- HTTP server --------------------------------------------------------
@@ -242,15 +281,18 @@ see or touch this computer directly. Your ONLY way to interact with it is the \
 AFTER the action, plus how many actions you have left. Run it like:
 
     act '{{"action": "screenshot"}}'
-    act '{{"action": "left_click", "coordinate": [512, 300]}}'
+    act '{{"action": "left_click", "coordinate": [960, 540]}}'
     act '{{"action": "type", "text": "hello"}}'
 
 After EVERY `act` call, VIEW the screenshot file it printed (read the image) \
 before deciding your next action. Start by taking a screenshot to see the \
 current screen.
 
-Coordinates are on a 0-1000 grid: [0,0] is top-left, [1000,1000] is \
-bottom-right, regardless of the real {width}x{height} resolution.
+Coordinates are PIXELS in the screenshot image you view, which is exactly \
+{width}x{height}: [0,0] is the top-left corner and [{width},{height}] is the \
+bottom-right. Read the pixel position of your target directly off the \
+screenshot. Windows may be small and not maximized, so aim at the center of \
+the exact element (menu label, button, field) you want.
 
 Available actions (the JSON `action` field):
 - screenshot                                        — just observe
@@ -388,7 +430,9 @@ class CliHarnessAgent:
         try:
             sandbox.build()
             sandbox.start(gateway_port=port, gateway_token=token, container_env=self.container_env())
-            prompt = build_harness_prompt(task, resolution, max_steps)
+            # The model sees display-sized frames, so the prompt's coordinate
+            # space is the display size, not the env's native resolution.
+            prompt = build_harness_prompt(task, (gateway.display_w, gateway.display_h), max_steps)
             (logs_dir / "prompt.txt").write_text(prompt)
             result = sandbox.exec(self.build_cli_command(), timeout_sec=self.timeout_sec)
             if result.returncode != 0 and self.verbose:

--- a/agents/shared/cli_harness.py
+++ b/agents/shared/cli_harness.py
@@ -1,0 +1,501 @@
+"""Shared machinery for running existing CLI coding harnesses (Claude Code,
+Codex CLI, ...) as gym-anything computer-use agents.
+
+Design (see the agents docs): the CLI never runs inside the task VM. It runs
+in a throwaway, GUI-less scratch container that can reach exactly one thing on
+the host — an in-process HTTP *action gateway* — and the model provider API.
+The container has no route to the env VM's VNC/SSH ports, so the CLI can only
+affect the environment through the gateway.
+
+The gateway speaks the same text action vocabulary the other agents use
+(``agents/shared/qwen_computer_use.py``): the CLI sends one action as a JSON
+string, the gateway parses it, calls ``env.step()``, and returns the
+post-action screenshot (base64 PNG) plus the remaining step budget. Inside the
+container a tiny ``act`` wrapper POSTs the command and writes the screenshot to
+a file the CLI then views. No MCP, no per-CLI protocol.
+
+Because the gateway calls ``env.step()`` for every action, step limits,
+timeouts, ``traj.jsonl``, frame capture, and verification all flow through
+``GymAnythingEnv`` unchanged — identical to every other agent. The gateway's
+own per-action log is the authoritative trajectory record.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import secrets
+import subprocess
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Optional
+
+from agents.shared.qwen_computer_use import parse_qwen3vl_response
+
+logger = logging.getLogger(__name__)
+
+
+# The single action the CLI can never issue meaningfully but might try; keep
+# the list here so both the prompt and the gateway agree.
+_TERMINATE_ACTIONS = {"terminate", "done", "finish"}
+
+
+def _obs_png_b64(obs: dict[str, Any]) -> Optional[str]:
+    """Extract the observation screenshot as a base64 PNG string, or None."""
+    if not isinstance(obs, dict):
+        return None
+    screen = obs.get("screen") or {}
+    if not isinstance(screen, dict):
+        return None
+    image = screen.get("image")
+    if image is not None and hasattr(image, "save"):
+        buffer = BytesIO()
+        image.save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+    if screen.get("png_b64"):
+        return screen["png_b64"]
+    path = screen.get("path")
+    if path and os.path.exists(path):
+        with open(path, "rb") as handle:
+            return base64.b64encode(handle.read()).decode("ascii")
+    return None
+
+
+class ActionGateway:
+    """Translate CLI action-command strings into ``env.step()`` calls.
+
+    The HTTP surface is a thin wrapper; ``step_from_command`` is the testable
+    core (no docker, no sockets). One request is in flight at a time (the CLI
+    blocks on each ``act``), so the single env instance is never touched
+    concurrently.
+    """
+
+    def __init__(
+        self,
+        env: Any,
+        resolution: tuple[int, int],
+        max_steps: int,
+        token: str,
+    ):
+        self.env = env
+        self.width, self.height = resolution
+        self.max_steps = max_steps
+        self.token = token
+        self.steps_taken = 0
+        self.transcript: list[dict[str, Any]] = []
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+
+    # --- action translation ------------------------------------------------
+
+    def _env_actions_for(self, command: str) -> tuple[list[dict[str, Any]], bool, Optional[str]]:
+        """Return (env_actions, is_terminal, error) for a command string.
+
+        Reuses ``parse_qwen3vl_response`` (single source of truth for the
+        vocabulary and 0-1000 -> pixel scaling) by wrapping the raw action
+        JSON in the tool-call envelope the parser expects.
+        """
+        try:
+            action_json = json.loads(command)
+        except (json.JSONDecodeError, TypeError) as exc:
+            return [], False, f"invalid action JSON: {exc}"
+
+        if not isinstance(action_json, dict) or "action" not in action_json:
+            return [], False, "action JSON must be an object with an 'action' key"
+
+        name = str(action_json["action"]).lower()
+        if name == "screenshot":
+            return [{"action": "screenshot"}], False, None
+        if name in _TERMINATE_ACTIONS:
+            return [], True, None
+
+        synthetic = (
+            '<tool_call>{"name": "computer_use", "arguments": '
+            + json.dumps(action_json)
+            + "}</tool_call>"
+        )
+        parsed = parse_qwen3vl_response(
+            synthetic,
+            scale_dims=True,
+            scale_dims_ratio=(self.width / 1000.0, self.height / 1000.0),
+        )
+        meta = parsed["metadata"]
+        if meta.get("parse_error"):
+            return [], False, f"could not parse action: {meta.get('conclusion')}"
+        env_actions = parsed["actions"]
+        if meta.get("wait_time") is not None:
+            env_actions = [{"action": "wait", "time": meta["wait_time"]}]
+        return env_actions, bool(meta.get("is_terminal")), None
+
+    def step_from_command(self, command: str) -> dict[str, Any]:
+        """Execute one action command; return the gateway response payload."""
+        if self.steps_taken >= self.max_steps:
+            obs = self.env.capture_observation()
+            return {
+                "step": self.steps_taken,
+                "budget_remaining": 0,
+                "done": True,
+                "error": "step budget exhausted",
+                "screenshot_b64": _obs_png_b64(obs),
+            }
+
+        env_actions, is_terminal, error = self._env_actions_for(command)
+
+        if error is not None:
+            # Do not consume budget on a malformed command; let the model retry.
+            obs = self.env.capture_observation()
+            self.transcript.append(
+                {"step": self.steps_taken, "command": command, "error": error}
+            )
+            return {
+                "step": self.steps_taken,
+                "budget_remaining": self.max_steps - self.steps_taken,
+                "done": False,
+                "error": error,
+                "screenshot_b64": _obs_png_b64(obs),
+            }
+
+        obs, _reward, done, _info = self.env.step(env_actions)
+        self.steps_taken += 1
+        self.transcript.append(
+            {
+                "step": self.steps_taken,
+                "command": command,
+                "env_actions": env_actions,
+                "terminal_requested": is_terminal,
+                "env_done": bool(done),
+            }
+        )
+        return {
+            "step": self.steps_taken,
+            "budget_remaining": max(0, self.max_steps - self.steps_taken),
+            "done": bool(done) or is_terminal or self.steps_taken >= self.max_steps,
+            "error": None,
+            "screenshot_b64": _obs_png_b64(obs),
+        }
+
+    # --- HTTP server --------------------------------------------------------
+
+    def start(self, host: str = "0.0.0.0") -> int:
+        """Start the gateway on an ephemeral port; return the port."""
+        gateway = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # silence default logging
+                pass
+
+            def do_POST(self) -> None:
+                if self.headers.get("X-Gateway-Token") != gateway.token:
+                    self.send_response(403)
+                    self.end_headers()
+                    return
+                length = int(self.headers.get("Content-Length", 0))
+                try:
+                    payload = json.loads(self.rfile.read(length) or b"{}")
+                    command = payload["command"]
+                except (json.JSONDecodeError, KeyError, ValueError) as exc:
+                    self.send_response(400)
+                    self.end_headers()
+                    self.wfile.write(json.dumps({"error": str(exc)}).encode())
+                    return
+                try:
+                    result = gateway.step_from_command(command)
+                except Exception as exc:  # keep the CLI alive on env hiccups
+                    logger.exception("gateway step failed")
+                    result = {"error": f"gateway error: {exc}", "done": False}
+                body = json.dumps(result).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._server = ThreadingHTTPServer((host, 0), _Handler)
+        port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        logger.info("Action gateway listening on %s:%d", host, port)
+        return port
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+
+def build_harness_prompt(task_description: str, resolution: tuple[int, int], max_steps: int) -> str:
+    """Instruction telling the CLI how to drive the computer through `act`."""
+    width, height = resolution
+    return f"""You are operating a remote computer to accomplish a task. You CANNOT \
+see or touch this computer directly. Your ONLY way to interact with it is the \
+`act` command, already installed on your PATH.
+
+`act` takes one JSON action string and returns the path to a screenshot taken \
+AFTER the action, plus how many actions you have left. Run it like:
+
+    act '{{"action": "screenshot"}}'
+    act '{{"action": "left_click", "coordinate": [512, 300]}}'
+    act '{{"action": "type", "text": "hello"}}'
+
+After EVERY `act` call, VIEW the screenshot file it printed (read the image) \
+before deciding your next action. Start by taking a screenshot to see the \
+current screen.
+
+Coordinates are on a 0-1000 grid: [0,0] is top-left, [1000,1000] is \
+bottom-right, regardless of the real {width}x{height} resolution.
+
+Available actions (the JSON `action` field):
+- screenshot                                        — just observe
+- left_click / right_click / double_click / triple_click, with "coordinate": [x, y]
+- mouse_move, with "coordinate": [x, y]
+- drag, with "coordinate": [x1, y1] and "coordinate2": [x2, y2]
+- type, with "text": "...", optional "enter": true, optional "clear": true
+- key, with "keys": ["ctrl", "s"]           — chord of held-then-released keys
+- scroll, with "coordinate": [x, y] and "pixels": <negative up / positive down>
+- wait, with "time": <seconds>
+- terminate, with "status": "success"       — when the task is fully done
+
+Rules:
+- You have at most {max_steps} actions. Each non-observation `act` call spends one.
+- Do NOT try to reach the computer any other way (no ssh, no editing files \
+directly, no network tricks). `act` is the only channel and the only thing \
+scored. Anything else is impossible and wastes turns.
+- When the task is fully complete, call `act '{{"action": "terminate", \
+"status": "success"}}'` and stop.
+
+Task:
+{task_description}
+"""
+
+
+_ACT_SCRIPT = r"""#!/usr/bin/env python3
+import sys, os, json, base64, urllib.request
+if len(sys.argv) < 2:
+    print("usage: act '<json action>'", file=sys.stderr); sys.exit(2)
+command = sys.argv[1]
+data = json.dumps({"command": command}).encode()
+req = urllib.request.Request(
+    os.environ["GATEWAY_URL"],
+    data=data,
+    headers={"Content-Type": "application/json",
+             "X-Gateway-Token": os.environ.get("GATEWAY_TOKEN", "")},
+)
+try:
+    resp = json.load(urllib.request.urlopen(req, timeout=180))
+except Exception as exc:
+    print(f"act: gateway request failed: {exc}", file=sys.stderr); sys.exit(1)
+if resp.get("screenshot_b64"):
+    os.makedirs("obs", exist_ok=True)
+    path = f"obs/step_{resp.get('step', 0):04d}.png"
+    with open(path, "wb") as fh:
+        fh.write(base64.b64decode(resp["screenshot_b64"]))
+    print(f"screenshot: {path}  (view this image before your next action)")
+if resp.get("error"):
+    print(f"error: {resp['error']}")
+print(f"budget_remaining: {resp.get('budget_remaining')}")
+if resp.get("done"):
+    print("EPISODE DONE: no further actions will be executed.")
+"""
+
+
+_DOCKERFILE_TEMPLATE = """FROM node:22-slim
+RUN apt-get update \\
+ && apt-get install -y --no-install-recommends curl ca-certificates python3 procps \\
+ && rm -rf /var/lib/apt/lists/*
+{install_block}
+COPY act /usr/local/bin/act
+RUN chmod +x /usr/local/bin/act
+WORKDIR /work
+"""
+
+
+class CliHarnessRunner:
+    """Owns the scratch container lifecycle and CLI invocation via `docker`.
+
+    All docker calls are isolated here so the parsing/gateway logic stays unit
+    testable without a daemon.
+    """
+
+    def __init__(
+        self,
+        image_tag: str,
+        install_block: str,
+        container_env: dict[str, str],
+        logs_dir: Path,
+    ):
+        self.image_tag = image_tag
+        self.install_block = install_block
+        self.container_env = container_env
+        self.logs_dir = Path(logs_dir)
+        self.container_name = f"gym-cli-harness-{secrets.token_hex(6)}"
+
+    def _run(self, args: list[str], timeout: Optional[int] = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout, check=False
+        )
+
+    def ensure_image(self) -> None:
+        """Build the scratch image if the tag is not already present."""
+        inspect = self._run(["docker", "image", "inspect", self.image_tag])
+        if inspect.returncode == 0:
+            logger.debug("Scratch image %s already present", self.image_tag)
+            return
+        with tempfile.TemporaryDirectory() as build_dir:
+            build_path = Path(build_dir)
+            (build_path / "act").write_text(_ACT_SCRIPT)
+            (build_path / "Dockerfile").write_text(
+                _DOCKERFILE_TEMPLATE.format(install_block=self.install_block)
+            )
+            logger.info("Building scratch image %s", self.image_tag)
+            result = self._run(
+                ["docker", "build", "-t", self.image_tag, str(build_path)],
+                timeout=1800,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to build scratch image {self.image_tag}:\n{result.stderr}"
+                )
+
+    def start_container(self, gateway_port: int, gateway_token: str) -> None:
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        env_args: list[str] = []
+        env = {
+            **self.container_env,
+            "GATEWAY_URL": f"http://host.docker.internal:{gateway_port}/act",
+            "GATEWAY_TOKEN": gateway_token,
+        }
+        for key, value in env.items():
+            if value:
+                env_args += ["-e", f"{key}={value}"]
+        args = [
+            "docker", "run", "-d", "--rm",
+            "--name", self.container_name,
+            # Reach the host gateway on Linux too (Docker Desktop already maps it).
+            "--add-host", "host.docker.internal:host-gateway",
+            "-v", f"{self.logs_dir}:/logs",
+            *env_args,
+            self.image_tag,
+            "sleep", "infinity",
+        ]
+        result = self._run(args, timeout=120)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to start scratch container:\n{result.stderr}")
+
+    def exec_cli(self, command: str, timeout_sec: int) -> subprocess.CompletedProcess:
+        """Run the CLI invocation inside the container, teeing stdout to /logs."""
+        wrapped = f"set -o pipefail; ({command}) 2>&1 | tee /logs/cli_stdout.txt"
+        return self._run(
+            ["docker", "exec", self.container_name, "bash", "-lc", wrapped],
+            timeout=timeout_sec,
+        )
+
+    def stop_container(self) -> None:
+        self._run(["docker", "rm", "-f", self.container_name], timeout=60)
+
+
+class CliHarnessAgent:
+    """Base for agents that delegate the episode to an external CLI harness.
+
+    Autonomous agents do not implement ``step()``. The evaluation loop calls
+    ``run_episode(env, task_description)`` once; inside it the CLI drives the
+    env through the action gateway. Subclasses supply the scratch image's
+    install block, the container env (API keys), and the CLI invocation.
+    """
+
+    autonomous = True
+
+    # Subclasses override these.
+    image_tag: str = "gym-anything-cli-harness:base"
+    install_block: str = ""
+
+    def __init__(self, agent_args: Optional[dict[str, Any]] = None, verbose: bool = False, debug: bool = False, **kwargs: Any):
+        self.agent_args = agent_args or {}
+        self.verbose = verbose
+        self.debug = debug
+        self.model = self.agent_args.get("model")
+        self.timeout_sec = int(self.agent_args.get("timeout_sec", 3600))
+        self.max_steps_override = self.agent_args.get("max_steps")
+        self.done = False
+        self.step_idx = -1
+        self.display_resolution: tuple[int, int] = (1920, 1080)
+        self.save_path: Optional[str] = None
+        self.task_description: str = ""
+        self._transcript: list[dict[str, Any]] = []
+
+    def init(self, task_description: str, display_resolution: tuple[int, int], save_path: str) -> None:
+        self.task_description = task_description
+        self.display_resolution = tuple(display_resolution)
+        self.save_path = save_path
+
+    # --- subclass hooks -----------------------------------------------------
+
+    def container_env(self) -> dict[str, str]:
+        """API keys / model config to inject into the scratch container."""
+        raise NotImplementedError
+
+    def build_cli_command(self) -> str:
+        """Shell command that runs the CLI headless inside the container.
+
+        The rendered instruction is available at ``/logs/prompt.txt`` inside
+        the container; read it from there to avoid shell-escaping a large
+        multi-line prompt.
+        """
+        raise NotImplementedError
+
+    # --- episode ------------------------------------------------------------
+
+    def run_episode(self, env: Any, task_description: Optional[str] = None) -> None:
+        task = task_description or self.task_description
+        resolution = self.display_resolution
+        max_steps = int(self.max_steps_override or getattr(env, "max_steps", None) or 50)
+
+        logs_dir = Path(self.save_path) / "cli_harness" if self.save_path else Path(tempfile.mkdtemp())
+        token = secrets.token_hex(16)
+        gateway = ActionGateway(env, resolution, max_steps, token)
+        runner = CliHarnessRunner(
+            image_tag=self.image_tag,
+            install_block=self.install_block,
+            container_env=self.container_env(),
+            logs_dir=logs_dir,
+        )
+
+        port = gateway.start()
+        try:
+            runner.ensure_image()
+            runner.start_container(port, token)
+            prompt = build_harness_prompt(task, resolution, max_steps)
+            (logs_dir / "prompt.txt").write_text(prompt)
+            result = runner.exec_cli(self.build_cli_command(), timeout_sec=self.timeout_sec)
+            if result.returncode != 0 and self.verbose:
+                logger.warning(
+                    "CLI exited with %d; stderr: %s", result.returncode, result.stderr[:2000]
+                )
+        except subprocess.TimeoutExpired:
+            logger.warning("CLI harness timed out after %ds", self.timeout_sec)
+        finally:
+            self._transcript = gateway.transcript
+            gateway.stop()
+            runner.stop_container()
+            self.done = True
+
+    def finish(self, *args: Any, **kwargs: Any) -> None:
+        if not self.save_path:
+            return
+        trajectory = {
+            "agent": type(self).__name__,
+            "model": self.model,
+            "task": self.task_description,
+            "steps": self._transcript,
+            "info": kwargs.get("info"),
+        }
+        try:
+            with open(f"{self.save_path}/trajectory.json", "w", encoding="utf-8") as handle:
+                json.dump(trajectory, handle, indent=2, default=str)
+        except OSError as exc:
+            logger.warning("Failed to write CLI harness trajectory: %s", exc)

--- a/agents/shared/cli_harness.py
+++ b/agents/shared/cli_harness.py
@@ -2,10 +2,11 @@
 Codex CLI, ...) as gym-anything computer-use agents.
 
 Design (see the agents docs): the CLI never runs inside the task VM. It runs
-in a throwaway, GUI-less scratch container that can reach exactly one thing on
-the host — an in-process HTTP *action gateway* — and the model provider API.
-The container has no route to the env VM's VNC/SSH ports, so the CLI can only
-affect the environment through the gateway.
+in a throwaway, GUI-less isolated sandbox (apptainer or docker, see
+``agent_sandbox.py``) that can reach exactly one thing on the host, an
+in-process HTTP *action gateway*, plus the model provider API. The env is a
+separate VM, so the CLI has no filesystem path into it and can only affect the
+environment through the gateway.
 
 The gateway speaks the same text action vocabulary the other agents use
 (``agents/shared/qwen_computer_use.py``): the CLI sends one action as a JSON
@@ -35,6 +36,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional
 
+from agents.shared.agent_sandbox import SandboxSpec, select_sandbox
 from agents.shared.qwen_computer_use import parse_qwen3vl_response
 
 logger = logging.getLogger(__name__)
@@ -304,99 +306,10 @@ if resp.get("done"):
 """
 
 
-_DOCKERFILE_TEMPLATE = """FROM node:22-slim
-RUN apt-get update \\
- && apt-get install -y --no-install-recommends curl ca-certificates python3 procps \\
- && rm -rf /var/lib/apt/lists/*
-{install_block}
-COPY act /usr/local/bin/act
-RUN chmod +x /usr/local/bin/act
-WORKDIR /work
-"""
-
-
-class CliHarnessRunner:
-    """Owns the scratch container lifecycle and CLI invocation via `docker`.
-
-    All docker calls are isolated here so the parsing/gateway logic stays unit
-    testable without a daemon.
-    """
-
-    def __init__(
-        self,
-        image_tag: str,
-        install_block: str,
-        container_env: dict[str, str],
-        logs_dir: Path,
-    ):
-        self.image_tag = image_tag
-        self.install_block = install_block
-        self.container_env = container_env
-        self.logs_dir = Path(logs_dir)
-        self.container_name = f"gym-cli-harness-{secrets.token_hex(6)}"
-
-    def _run(self, args: list[str], timeout: Optional[int] = None) -> subprocess.CompletedProcess:
-        return subprocess.run(
-            args, capture_output=True, text=True, timeout=timeout, check=False
-        )
-
-    def ensure_image(self) -> None:
-        """Build the scratch image if the tag is not already present."""
-        inspect = self._run(["docker", "image", "inspect", self.image_tag])
-        if inspect.returncode == 0:
-            logger.debug("Scratch image %s already present", self.image_tag)
-            return
-        with tempfile.TemporaryDirectory() as build_dir:
-            build_path = Path(build_dir)
-            (build_path / "act").write_text(_ACT_SCRIPT)
-            (build_path / "Dockerfile").write_text(
-                _DOCKERFILE_TEMPLATE.format(install_block=self.install_block)
-            )
-            logger.info("Building scratch image %s", self.image_tag)
-            result = self._run(
-                ["docker", "build", "-t", self.image_tag, str(build_path)],
-                timeout=1800,
-            )
-            if result.returncode != 0:
-                raise RuntimeError(
-                    f"Failed to build scratch image {self.image_tag}:\n{result.stderr}"
-                )
-
-    def start_container(self, gateway_port: int, gateway_token: str) -> None:
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
-        env_args: list[str] = []
-        env = {
-            **self.container_env,
-            "GATEWAY_URL": f"http://host.docker.internal:{gateway_port}/act",
-            "GATEWAY_TOKEN": gateway_token,
-        }
-        for key, value in env.items():
-            if value:
-                env_args += ["-e", f"{key}={value}"]
-        args = [
-            "docker", "run", "-d", "--rm",
-            "--name", self.container_name,
-            # Reach the host gateway on Linux too (Docker Desktop already maps it).
-            "--add-host", "host.docker.internal:host-gateway",
-            "-v", f"{self.logs_dir}:/logs",
-            *env_args,
-            self.image_tag,
-            "sleep", "infinity",
-        ]
-        result = self._run(args, timeout=120)
-        if result.returncode != 0:
-            raise RuntimeError(f"Failed to start scratch container:\n{result.stderr}")
-
-    def exec_cli(self, command: str, timeout_sec: int) -> subprocess.CompletedProcess:
-        """Run the CLI invocation inside the container, teeing stdout to /logs."""
-        wrapped = f"set -o pipefail; ({command}) 2>&1 | tee /logs/cli_stdout.txt"
-        return self._run(
-            ["docker", "exec", self.container_name, "bash", "-lc", wrapped],
-            timeout=timeout_sec,
-        )
-
-    def stop_container(self) -> None:
-        self._run(["docker", "rm", "-f", self.container_name], timeout=60)
+# The scratch image is built by the sandbox backend (agent_sandbox.py); the
+# per-agent bits (base image, CLI install line, invocation) live on the agent
+# subclasses. This module owns only the gateway, the prompt, and the `act`
+# script above.
 
 
 class CliHarnessAgent:
@@ -404,15 +317,17 @@ class CliHarnessAgent:
 
     Autonomous agents do not implement ``step()``. The evaluation loop calls
     ``run_episode(env, task_description)`` once; inside it the CLI drives the
-    env through the action gateway. Subclasses supply the scratch image's
-    install block, the container env (API keys), and the CLI invocation.
+    env through the action gateway, from inside an isolated sandbox
+    (``agent_sandbox.py``). Subclasses supply the scratch image's base + CLI
+    install line, the container env (API keys), and the CLI invocation.
     """
 
     autonomous = True
 
     # Subclasses override these.
-    image_tag: str = "gym-anything-cli-harness:base"
-    install_block: str = ""
+    sandbox_name: str = "cli"
+    sandbox_base_image: str = "node:22-slim"
+    sandbox_install: str = ""
 
     def __init__(self, agent_args: Optional[dict[str, Any]] = None, verbose: bool = False, debug: bool = False, **kwargs: Any):
         self.agent_args = agent_args or {}
@@ -448,6 +363,14 @@ class CliHarnessAgent:
         """
         raise NotImplementedError
 
+    def sandbox_spec(self) -> SandboxSpec:
+        return SandboxSpec(
+            name=self.sandbox_name,
+            base_image=self.sandbox_base_image,
+            install=self.sandbox_install,
+            act_script=_ACT_SCRIPT,
+        )
+
     # --- episode ------------------------------------------------------------
 
     def run_episode(self, env: Any, task_description: Optional[str] = None) -> None:
@@ -456,22 +379,18 @@ class CliHarnessAgent:
         max_steps = int(self.max_steps_override or getattr(env, "max_steps", None) or 50)
 
         logs_dir = Path(self.save_path) / "cli_harness" if self.save_path else Path(tempfile.mkdtemp())
+        logs_dir.mkdir(parents=True, exist_ok=True)
         token = secrets.token_hex(16)
         gateway = ActionGateway(env, resolution, max_steps, token)
-        runner = CliHarnessRunner(
-            image_tag=self.image_tag,
-            install_block=self.install_block,
-            container_env=self.container_env(),
-            logs_dir=logs_dir,
-        )
+        sandbox = select_sandbox(self.sandbox_spec(), logs_dir)
 
-        port = gateway.start()
+        port = gateway.start(host=sandbox.gateway_bind_host)
         try:
-            runner.ensure_image()
-            runner.start_container(port, token)
+            sandbox.build()
+            sandbox.start(gateway_port=port, gateway_token=token, container_env=self.container_env())
             prompt = build_harness_prompt(task, resolution, max_steps)
             (logs_dir / "prompt.txt").write_text(prompt)
-            result = runner.exec_cli(self.build_cli_command(), timeout_sec=self.timeout_sec)
+            result = sandbox.exec(self.build_cli_command(), timeout_sec=self.timeout_sec)
             if result.returncode != 0 and self.verbose:
                 logger.warning(
                     "CLI exited with %d; stderr: %s", result.returncode, result.stderr[:2000]
@@ -481,7 +400,7 @@ class CliHarnessAgent:
         finally:
             self._transcript = gateway.transcript
             gateway.stop()
-            runner.stop_container()
+            sandbox.stop()
             self.done = True
 
     def finish(self, *args: Any, **kwargs: Any) -> None:

--- a/docs/content/docs/agents/index.mdx
+++ b/docs/content/docs/agents/index.mdx
@@ -96,19 +96,30 @@ detects the flag, calls `run_episode` once, and then runs the same `mark_done`
 verification as every other agent.
 
 The CLI never runs inside the task VM. It runs in a throwaway, GUI-less
-scratch Docker container that can reach exactly one thing on the host: an
-in-process **action gateway**. The CLI sends one action as a JSON string
-(the same vocabulary the other agents use) through a small `act` command, the
-gateway calls `env.step()` and returns the post-action screenshot plus the
-remaining step budget. The container has no route to the env's VNC/SSH ports,
-so the CLI can only affect the environment through the gateway, and it can
-never bypass the mouse-and-keyboard action space by editing files or the
-database directly. The shared machinery lives in
+scratch container that can reach exactly one thing on the host: an in-process
+**action gateway**. The CLI sends one action as a JSON string (the same
+vocabulary the other agents use) through a small `act` command, the gateway
+calls `env.step()` and returns the post-action screenshot plus the remaining
+step budget. So the CLI can only affect the environment through the gateway,
+and it can never bypass the mouse-and-keyboard action space by editing files
+or the database directly. The shared machinery lives in
 `agents/shared/cli_harness.py`.
 
-These agents need Docker on the host and the relevant API key
+The sandbox is backend-agnostic and auto-selected the way env runners are
+(`GYM_ANYTHING_AGENT_SANDBOX` override, then detect), in
+`agents/shared/agent_sandbox.py`: **Apptainer** (rootless, no daemon, the
+primary path on clusters) or **Docker** (daemon machines, which additionally
+get bridge network isolation). There is deliberately no no-isolation fallback:
+if neither is available the run fails rather than launch a permission-bypassed
+CLI unsandboxed. File and process isolation hold on both backends, and the env
+is a separate VM either way, so the agent has no filesystem path into it. On
+Docker the bridge also blocks any route to the env's ports; under rootless
+Apptainer (shared host network) that guarantee softens to the agent only ever
+being handed the gateway and never the env's SSH/VNC credentials.
+
+These agents need Apptainer or Docker on the host and the relevant API key
 (`ANTHROPIC_API_KEY` for Claude Code, `OPENAI_API_KEY` for Codex), which is
-injected into the scratch container per run, never baked into the image.
+injected into the sandbox per run, never baked into the image.
 
 ## The Fastest Way To Try One
 

--- a/docs/content/docs/agents/index.mdx
+++ b/docs/content/docs/agents/index.mdx
@@ -38,8 +38,10 @@ We currently ship these agents:
 
 - `ClaudeAgent`
 - `Gemini3Agent`
+- `GeminiComputerUseAgent`, `GPT54ComputerUseAgent` (provider-native computer-use tools)
 - `Qwen3VLAgent`
 - `KimiAzureAgent`
+- `ClaudeCodeAgent`, `CodexCliAgent` (external CLI harnesses, see below)
 
 These classes are exported through `agents.agents`, which is why the evaluation commands refer to names such as `--agent ClaudeAgent`.
 
@@ -83,6 +85,30 @@ The `actions` list can contain normal environment actions such as mouse and keyb
 - `{"action": "wait", "time": 1.5}`
 
 Those control actions are handled by the environment layer, not by the evaluation loop.
+
+## Autonomous Agents (External CLI Harnesses)
+
+Some agents are not step-based. `ClaudeCodeAgent` and `CodexCliAgent` wrap
+existing coding CLIs (Claude Code, Codex) and let the CLI run the whole
+episode on its own. These set a class flag `autonomous = True` and implement
+`run_episode(env, task_description)` instead of `step(...)`. `run_single.py`
+detects the flag, calls `run_episode` once, and then runs the same `mark_done`
+verification as every other agent.
+
+The CLI never runs inside the task VM. It runs in a throwaway, GUI-less
+scratch Docker container that can reach exactly one thing on the host: an
+in-process **action gateway**. The CLI sends one action as a JSON string
+(the same vocabulary the other agents use) through a small `act` command, the
+gateway calls `env.step()` and returns the post-action screenshot plus the
+remaining step budget. The container has no route to the env's VNC/SSH ports,
+so the CLI can only affect the environment through the gateway, and it can
+never bypass the mouse-and-keyboard action space by editing files or the
+database directly. The shared machinery lives in
+`agents/shared/cli_harness.py`.
+
+These agents need Docker on the host and the relevant API key
+(`ANTHROPIC_API_KEY` for Claude Code, `OPENAI_API_KEY` for Codex), which is
+injected into the scratch container per run, never baked into the image.
 
 ## The Fastest Way To Try One
 

--- a/tests/test_agent_evaluation_contract.py
+++ b/tests/test_agent_evaluation_contract.py
@@ -265,6 +265,67 @@ class AgentEvaluationContractTests(unittest.TestCase):
             self.assertEqual(records[0]["event"], "setup")
             self.assertTrue(any(record.get("event") == "iteration" for record in records))
 
+    def test_run_single_autonomous_agent_delegates_and_verifies(self) -> None:
+        """Autonomous agents skip the step loop: run_episode is called once and
+        mark_done still runs so verification stays on the shared path."""
+
+        class _FakeAutonomous:
+            instances: list = []
+            autonomous = True
+
+            def __init__(self, *args, **kwargs) -> None:
+                self.done = False
+                self.ran_with = None
+                self.finish_info = None
+                type(self).instances.append(self)
+
+            def init(self, task_description, display_resolution, save_path):
+                self.task_description = task_description
+
+            def run_episode(self, env, task_description=None):
+                self.ran_with = (env, task_description)
+
+            def finish(self, *args, **kwargs):
+                self.finish_info = kwargs.get("info")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_env = _FakeEnv(Path(tmp))
+            args = SimpleNamespace(
+                env_dir="demo-env",
+                seed=42,
+                task="demo-task",
+                steps=2,
+                agent="FakeAutonomous",
+                agent_args=json.dumps({"model": "claude"}),
+                debug=False,
+                debug_low=False,
+                verbose=False,
+                setup_code="none",
+                use_cache=False,
+                cache_level="pre_start",
+                use_savevm=False,
+                vlm_backend="local",
+                vlm_base_url="http://localhost:8080/v1",
+                vlm_model="demo-model",
+                remote_url=None,
+                remote_timeout=300,
+                remote_worker_reset_policy="core",
+            )
+
+            with mock.patch.object(run_single_module, "from_config", return_value=fake_env), \
+                 mock.patch.object(run_single_module.agent_registry, "FakeAutonomous", _FakeAutonomous, create=True):
+                _FakeAutonomous.instances.clear()
+                result = run_single_module.run_single(args)
+
+            self.assertEqual(result, 0)
+            agent = _FakeAutonomous.instances[0]
+            # run_episode was called with the env; the step loop never ran.
+            self.assertIs(agent.ran_with[0], fake_env)
+            # Exactly one env.step call: the mark_done verification.
+            self.assertEqual(fake_env.step_calls, [([], True)])
+            self.assertEqual(agent.finish_info["verifier"]["score"], 100)
+            self.assertTrue(fake_env.closed)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_sandbox.py
+++ b/tests/test_agent_sandbox.py
@@ -1,0 +1,103 @@
+"""Offline tests for the agent sandbox abstraction: backend selection and
+image-recipe rendering. No docker/apptainer daemon required.
+"""
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from agents.shared import agent_sandbox
+from agents.shared.agent_sandbox import (
+    ApptainerSandbox,
+    DockerSandbox,
+    SandboxSpec,
+    select_sandbox,
+)
+
+
+def _spec():
+    return SandboxSpec(
+        name="claude",
+        base_image="node:22-slim",
+        install="npm install -g @anthropic-ai/claude-code",
+        act_script="#!/usr/bin/env python3\n",
+    )
+
+
+class SelectionTests(unittest.TestCase):
+    def test_explicit_override_apptainer(self):
+        with mock.patch.dict("os.environ", {"GYM_ANYTHING_AGENT_SANDBOX": "apptainer"}):
+            sb = select_sandbox(_spec(), Path("/tmp/x"))
+        self.assertIsInstance(sb, ApptainerSandbox)
+
+    def test_explicit_override_docker(self):
+        with mock.patch.dict("os.environ", {"GYM_ANYTHING_AGENT_SANDBOX": "docker"}):
+            sb = select_sandbox(_spec(), Path("/tmp/x"))
+        self.assertIsInstance(sb, DockerSandbox)
+
+    def test_unknown_override_raises(self):
+        with mock.patch.dict("os.environ", {"GYM_ANYTHING_AGENT_SANDBOX": "podman"}):
+            with self.assertRaises(ValueError):
+                select_sandbox(_spec(), Path("/tmp/x"))
+
+    def test_autodetect_prefers_apptainer(self):
+        with mock.patch.dict("os.environ", {}, clear=False) as _env, \
+             mock.patch.object(agent_sandbox, "_apptainer_available", return_value=True), \
+             mock.patch.object(agent_sandbox, "_docker_available", return_value=True):
+            import os
+            os.environ.pop("GYM_ANYTHING_AGENT_SANDBOX", None)
+            sb = select_sandbox(_spec(), Path("/tmp/x"))
+        self.assertIsInstance(sb, ApptainerSandbox)
+
+    def test_autodetect_falls_to_docker(self):
+        with mock.patch.object(agent_sandbox, "_apptainer_available", return_value=False), \
+             mock.patch.object(agent_sandbox, "_docker_available", return_value=True):
+            import os
+            os.environ.pop("GYM_ANYTHING_AGENT_SANDBOX", None)
+            sb = select_sandbox(_spec(), Path("/tmp/x"))
+        self.assertIsInstance(sb, DockerSandbox)
+
+    def test_no_backend_refuses_rather_than_no_isolation(self):
+        with mock.patch.object(agent_sandbox, "_apptainer_available", return_value=False), \
+             mock.patch.object(agent_sandbox, "_docker_available", return_value=False):
+            import os
+            os.environ.pop("GYM_ANYTHING_AGENT_SANDBOX", None)
+            with self.assertRaises(RuntimeError):
+                select_sandbox(_spec(), Path("/tmp/x"))
+
+
+class RenderingTests(unittest.TestCase):
+    def test_dockerfile_layers_common_then_cli(self):
+        df = DockerSandbox(_spec(), Path("/tmp/x")).dockerfile()
+        self.assertIn("FROM node:22-slim", df)
+        self.assertIn("apt-get install", df)
+        self.assertIn("npm install -g @anthropic-ai/claude-code", df)
+        self.assertIn("COPY act /usr/local/bin/act", df)
+        # common install must precede the CLI install
+        self.assertLess(df.index("apt-get install"), df.index("npm install"))
+
+    def test_apptainer_def_bootstraps_from_docker(self):
+        d = ApptainerSandbox(_spec(), Path("/tmp/x")).definition()
+        self.assertIn("Bootstrap: docker", d)
+        self.assertIn("From: node:22-slim", d)
+        self.assertIn("%post", d)
+        self.assertIn("npm install -g @anthropic-ai/claude-code", d)
+        self.assertIn("act /usr/local/bin/act", d)
+
+    def test_gateway_url_and_bind_differ_by_backend(self):
+        apptainer = ApptainerSandbox(_spec(), Path("/tmp/x"))
+        docker = DockerSandbox(_spec(), Path("/tmp/x"))
+        self.assertEqual(apptainer.gateway_bind_host, "127.0.0.1")
+        self.assertEqual(docker.gateway_bind_host, "0.0.0.0")
+        self.assertIn("127.0.0.1:8000", apptainer.gateway_url(8000))
+        self.assertIn("host.docker.internal:8000", docker.gateway_url(8000))
+
+    def test_spec_digest_stable_and_sensitive(self):
+        s1 = _spec()
+        s2 = SandboxSpec("claude", "node:22-slim", "npm install -g @anthropic-ai/claude-code", "#!/usr/bin/env python3\n")
+        self.assertEqual(s1.digest(), s2.digest())
+        s3 = SandboxSpec("claude", "node:22-slim", "npm install -g @openai/codex", "#!/usr/bin/env python3\n")
+        self.assertNotEqual(s1.digest(), s3.digest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_harness_gateway.py
+++ b/tests/test_cli_harness_gateway.py
@@ -1,22 +1,33 @@
 """Offline tests for the CLI-harness action gateway.
 
 Covers the testable core (command -> env.step translation, budget
-enforcement, screenshot extraction, prompt) with a fake env. No docker, no
-sockets.
+enforcement, display resize + coordinate scaling, prompt) with a fake env.
+No docker, no sockets.
 """
 import base64
+import io
 import unittest
-from types import SimpleNamespace
+
+from PIL import Image
 
 from agents.shared.cli_harness import (
     ActionGateway,
     build_harness_prompt,
-    _obs_png_b64,
+    _obs_png_bytes,
 )
 
 
+def _png(width=1920, height=1080, color=(20, 30, 40)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+_NATIVE_PNG = _png(1920, 1080)
+
+
 class FakeEnv:
-    """Minimal env: records step() calls, returns a distinct fake screenshot."""
+    """Minimal env: records step() calls, returns a real native-res PNG frame."""
 
     def __init__(self, max_steps=5, done_after=None):
         self.max_steps = max_steps
@@ -25,7 +36,7 @@ class FakeEnv:
         self._done_after = done_after
 
     def _obs(self):
-        return {"screen": {"png_b64": base64.b64encode(f"frame{self._n}".encode()).decode()}}
+        return {"screen": {"png_b64": base64.b64encode(_NATIVE_PNG).decode()}}
 
     def step(self, actions, **kwargs):
         self.calls.append(actions)
@@ -41,12 +52,32 @@ def _gateway(env, resolution=(1920, 1080)):
     return ActionGateway(env, resolution, max_steps=env.max_steps, token="tok")
 
 
+class DisplayScalingTests(unittest.TestCase):
+    def test_gateway_computes_display_and_ratio(self):
+        gw = _gateway(FakeEnv())
+        # 1920x1080 downscaled to a 1280 long side -> 1280x720, ratio 1.5.
+        self.assertEqual((gw.display_w, gw.display_h), (1280, 720))
+        self.assertAlmostEqual(gw.ratio_x, 1.5)
+        self.assertAlmostEqual(gw.ratio_y, 1.5)
+
+    def test_small_env_is_not_upscaled(self):
+        gw = _gateway(FakeEnv(), resolution=(800, 600))
+        self.assertEqual((gw.display_w, gw.display_h), (800, 600))
+        self.assertAlmostEqual(gw.ratio_x, 1.0)
+
+    def test_served_screenshot_is_resized_to_display(self):
+        gw = _gateway(FakeEnv())
+        resp = gw.step_from_command('{"action": "screenshot"}')
+        img = Image.open(io.BytesIO(base64.b64decode(resp["screenshot_b64"])))
+        self.assertEqual(img.size, (1280, 720))
+
+
 class CommandTranslationTests(unittest.TestCase):
-    def test_left_click_scales_from_0_1000_grid(self):
+    def test_left_click_scales_display_pixels_to_native(self):
         env = FakeEnv()
         gw = _gateway(env)
-        resp = gw.step_from_command('{"action": "left_click", "coordinate": [500, 500]}')
-        # 500/1000 * 1920 = 960 ; 500/1000 * 1080 = 540
+        # Model clicks (640, 360) in the 1280x720 display -> (960, 540) native.
+        resp = gw.step_from_command('{"action": "left_click", "coordinate": [640, 360]}')
         self.assertEqual(env.calls[-1], [{"mouse": {"left_click": [960, 540]}}])
         self.assertEqual(resp["budget_remaining"], 4)
         self.assertIsNotNone(resp["screenshot_b64"])
@@ -83,14 +114,15 @@ class CommandTranslationTests(unittest.TestCase):
         gw.step_from_command('{"action": "wait", "time": 2.5}')
         self.assertEqual(env.calls[-1], [{"action": "wait", "time": 2.5}])
 
-    def test_drag_uses_two_coordinates(self):
+    def test_drag_scales_both_coordinates(self):
         env = FakeEnv()
         gw = _gateway(env)
         gw.step_from_command(
-            '{"action": "drag", "coordinate": [0, 0], "coordinate2": [1000, 1000]}'
+            '{"action": "drag", "coordinate": [100, 200], "coordinate2": [600, 400]}'
         )
+        # each display coord * 1.5 -> native
         self.assertEqual(
-            env.calls[-1], [{"mouse": {"left_click_drag": [[0, 0], [1920, 1080]]}}]
+            env.calls[-1], [{"mouse": {"left_click_drag": [[150, 300], [900, 600]]}}]
         )
 
 
@@ -143,41 +175,46 @@ class BudgetTests(unittest.TestCase):
         gw.step_from_command('{"action": "screenshot"}')
         gw.step_from_command('{"action": "left_click", "coordinate": [1, 1]}')
         self.assertEqual(len(gw.transcript), 2)
+        # 1 * 1.5 -> int(1.5) == 1
         self.assertEqual(gw.transcript[1]["env_actions"], [{"mouse": {"left_click": [1, 1]}}])
 
 
 class ObservationExtractionTests(unittest.TestCase):
-    def test_png_b64_from_path(self):
+    def test_png_bytes_from_path(self):
         import tempfile, os
         with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
-            fh.write(b"\x89PNG-fake")
+            fh.write(_NATIVE_PNG)
             path = fh.name
         try:
-            b64 = _obs_png_b64({"screen": {"path": path}})
-            self.assertEqual(base64.b64decode(b64), b"\x89PNG-fake")
+            self.assertEqual(_obs_png_bytes({"screen": {"path": path}}), _NATIVE_PNG)
         finally:
             os.unlink(path)
 
-    def test_png_b64_from_pil_like_image(self):
+    def test_png_bytes_from_b64(self):
+        b64 = base64.b64encode(_NATIVE_PNG).decode()
+        self.assertEqual(_obs_png_bytes({"screen": {"png_b64": b64}}), _NATIVE_PNG)
+
+    def test_png_bytes_from_pil_like_image(self):
         class FakeImage:
             def save(self, buffer, format):  # noqa: A002
                 buffer.write(b"pilbytes")
 
-        b64 = _obs_png_b64({"screen": {"image": FakeImage()}})
-        self.assertEqual(base64.b64decode(b64), b"pilbytes")
+        self.assertEqual(_obs_png_bytes({"screen": {"image": FakeImage()}}), b"pilbytes")
 
-    def test_png_b64_missing_returns_none(self):
-        self.assertIsNone(_obs_png_b64({"screen": {}}))
-        self.assertIsNone(_obs_png_b64({}))
+    def test_png_bytes_missing_returns_none(self):
+        self.assertIsNone(_obs_png_bytes({"screen": {}}))
+        self.assertIsNone(_obs_png_bytes({}))
 
 
 class PromptTests(unittest.TestCase):
     def test_prompt_contains_task_budget_and_act_usage(self):
-        prompt = build_harness_prompt("Fill the background green.", (1920, 1080), 40)
+        # build_harness_prompt is given the display resolution.
+        prompt = build_harness_prompt("Fill the background green.", (1280, 720), 40)
         self.assertIn("Fill the background green.", prompt)
         self.assertIn("at most 40 actions", prompt)
         self.assertIn("act '{", prompt)
-        self.assertIn("0-1000 grid", prompt)
+        self.assertIn("PIXELS", prompt)
+        self.assertIn("1280x720", prompt)
         self.assertIn("terminate", prompt)
 
 

--- a/tests/test_cli_harness_gateway.py
+++ b/tests/test_cli_harness_gateway.py
@@ -1,0 +1,185 @@
+"""Offline tests for the CLI-harness action gateway.
+
+Covers the testable core (command -> env.step translation, budget
+enforcement, screenshot extraction, prompt) with a fake env. No docker, no
+sockets.
+"""
+import base64
+import unittest
+from types import SimpleNamespace
+
+from agents.shared.cli_harness import (
+    ActionGateway,
+    build_harness_prompt,
+    _obs_png_b64,
+)
+
+
+class FakeEnv:
+    """Minimal env: records step() calls, returns a distinct fake screenshot."""
+
+    def __init__(self, max_steps=5, done_after=None):
+        self.max_steps = max_steps
+        self.calls: list[list] = []
+        self._n = 0
+        self._done_after = done_after
+
+    def _obs(self):
+        return {"screen": {"png_b64": base64.b64encode(f"frame{self._n}".encode()).decode()}}
+
+    def step(self, actions, **kwargs):
+        self.calls.append(actions)
+        self._n += 1
+        done = self._done_after is not None and self._n >= self._done_after
+        return self._obs(), 0.0, done, {}
+
+    def capture_observation(self):
+        return self._obs()
+
+
+def _gateway(env, resolution=(1920, 1080)):
+    return ActionGateway(env, resolution, max_steps=env.max_steps, token="tok")
+
+
+class CommandTranslationTests(unittest.TestCase):
+    def test_left_click_scales_from_0_1000_grid(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        resp = gw.step_from_command('{"action": "left_click", "coordinate": [500, 500]}')
+        # 500/1000 * 1920 = 960 ; 500/1000 * 1080 = 540
+        self.assertEqual(env.calls[-1], [{"mouse": {"left_click": [960, 540]}}])
+        self.assertEqual(resp["budget_remaining"], 4)
+        self.assertIsNotNone(resp["screenshot_b64"])
+
+    def test_type_with_enter_and_clear(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        gw.step_from_command('{"action": "type", "text": "hi", "clear": true, "enter": true}')
+        self.assertEqual(
+            env.calls[-1],
+            [
+                {"keyboard": {"keys": ["ctrl", "a"]}},
+                {"keyboard": {"text": "hi"}},
+                {"keyboard": {"keys": ["Return"]}},
+            ],
+        )
+
+    def test_key_chord(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        gw.step_from_command('{"action": "key", "keys": ["ctrl", "s"]}')
+        self.assertEqual(env.calls[-1], [{"keyboard": {"keys": ["ctrl", "s"]}}])
+
+    def test_screenshot_only_still_steps(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        resp = gw.step_from_command('{"action": "screenshot"}')
+        self.assertEqual(env.calls[-1], [{"action": "screenshot"}])
+        self.assertFalse(resp["done"])
+
+    def test_wait_maps_to_wait_action(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        gw.step_from_command('{"action": "wait", "time": 2.5}')
+        self.assertEqual(env.calls[-1], [{"action": "wait", "time": 2.5}])
+
+    def test_drag_uses_two_coordinates(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        gw.step_from_command(
+            '{"action": "drag", "coordinate": [0, 0], "coordinate2": [1000, 1000]}'
+        )
+        self.assertEqual(
+            env.calls[-1], [{"mouse": {"left_click_drag": [[0, 0], [1920, 1080]]}}]
+        )
+
+
+class TerminalAndErrorTests(unittest.TestCase):
+    def test_terminate_sets_done_without_env_action(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        resp = gw.step_from_command('{"action": "terminate", "status": "success"}')
+        self.assertTrue(resp["done"])
+        self.assertEqual(env.calls[-1], [])
+
+    def test_malformed_json_does_not_consume_budget(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        resp = gw.step_from_command("not json")
+        self.assertIn("invalid action JSON", resp["error"])
+        self.assertEqual(resp["budget_remaining"], 5)  # unchanged
+        self.assertEqual(len(env.calls), 0)  # no env.step
+        self.assertIsNotNone(resp["screenshot_b64"])  # still returns a frame
+
+    def test_missing_action_key_is_error(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        resp = gw.step_from_command('{"coordinate": [1, 2]}')
+        self.assertIn("action", resp["error"])
+        self.assertEqual(len(env.calls), 0)
+
+
+class BudgetTests(unittest.TestCase):
+    def test_budget_exhaustion_blocks_further_steps(self):
+        env = FakeEnv(max_steps=2)
+        gw = _gateway(env)
+        gw.step_from_command('{"action": "screenshot"}')
+        r2 = gw.step_from_command('{"action": "screenshot"}')
+        self.assertEqual(r2["budget_remaining"], 0)
+        self.assertTrue(r2["done"])
+        r3 = gw.step_from_command('{"action": "screenshot"}')
+        self.assertEqual(r3["error"], "step budget exhausted")
+        self.assertEqual(len(env.calls), 2)  # third was refused
+
+    def test_env_done_propagates(self):
+        env = FakeEnv(max_steps=10, done_after=1)
+        gw = _gateway(env)
+        resp = gw.step_from_command('{"action": "left_click", "coordinate": [1, 1]}')
+        self.assertTrue(resp["done"])
+
+    def test_transcript_records_each_action(self):
+        env = FakeEnv()
+        gw = _gateway(env)
+        gw.step_from_command('{"action": "screenshot"}')
+        gw.step_from_command('{"action": "left_click", "coordinate": [1, 1]}')
+        self.assertEqual(len(gw.transcript), 2)
+        self.assertEqual(gw.transcript[1]["env_actions"], [{"mouse": {"left_click": [1, 1]}}])
+
+
+class ObservationExtractionTests(unittest.TestCase):
+    def test_png_b64_from_path(self):
+        import tempfile, os
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+            fh.write(b"\x89PNG-fake")
+            path = fh.name
+        try:
+            b64 = _obs_png_b64({"screen": {"path": path}})
+            self.assertEqual(base64.b64decode(b64), b"\x89PNG-fake")
+        finally:
+            os.unlink(path)
+
+    def test_png_b64_from_pil_like_image(self):
+        class FakeImage:
+            def save(self, buffer, format):  # noqa: A002
+                buffer.write(b"pilbytes")
+
+        b64 = _obs_png_b64({"screen": {"image": FakeImage()}})
+        self.assertEqual(base64.b64decode(b64), b"pilbytes")
+
+    def test_png_b64_missing_returns_none(self):
+        self.assertIsNone(_obs_png_b64({"screen": {}}))
+        self.assertIsNone(_obs_png_b64({}))
+
+
+class PromptTests(unittest.TestCase):
+    def test_prompt_contains_task_budget_and_act_usage(self):
+        prompt = build_harness_prompt("Fill the background green.", (1920, 1080), 40)
+        self.assertIn("Fill the background green.", prompt)
+        self.assertIn("at most 40 actions", prompt)
+        self.assertIn("act '{", prompt)
+        self.assertIn("0-1000 grid", prompt)
+        self.assertIn("terminate", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Runs existing coding CLIs (Claude Code, Codex) as gym-anything computer-use agents, without letting them run inside the task VM. Running a shell agent inside the env would let it bypass the GUI entirely (edit the `.xcf` on disk, write to the Odoo DB the verifier checks), so it would measure "can a shell game the verifier," not "can this agent operate software." Instead the CLI is confined to the same mouse/keyboard/screenshot action space as every other agent.

## How it works

- The CLI runs in a throwaway, GUI-less **scratch Docker container**, owned by the agent (built/started in `run_episode`, torn down after). The container can reach exactly one thing on the host: an in-process **action gateway**. It has no route to the env VM's VNC/SSH ports.
- The CLI sends one action as a JSON string (same vocabulary as the other agents, parsed via `parse_qwen3vl_response`) through a tiny `act` wrapper. The gateway calls `env.step()`, enforces the step budget server-side, and returns the post-action screenshot as base64, which `act` writes to a file the CLI views. No MCP, no per-CLI protocol.
- Because every action goes through `env.step()`, step limits, timeouts, `traj.jsonl`, frame capture, and verification are identical to every other agent. The gateway's own per-action log is the authoritative trajectory.

## Structure

- `agents/shared/cli_harness.py`: `ActionGateway` (parsing + `env.step` + budget, the testable core), `CliHarnessRunner` (docker lifecycle + `act` script + Dockerfile), `CliHarnessAgent` (autonomous base).
- `agents/agents/claude_code.py`, `agents/agents/codex_cli.py`: thin subclasses (install line, container env, CLI invocation with vendor bypass flags).
- `run_single.py`: autonomous branch — `run_episode` once, then the shared `mark_done` verification.

## Test plan

- 16 offline gateway tests: command translation (0-1000 scaling, clicks, type, key, drag, wait, terminate), budget enforcement, malformed-command handling, screenshot extraction, prompt.
- One `run_single` autonomous-branch test (delegates to `run_episode`, still runs `mark_done`).
- Live HTTP round-trip smoke-tested locally (403 on bad token, steps on good token, clean shutdown).
- Full suite: 226 passed, 22 skipped.
- Not run end-to-end against a real container (needs Docker + API keys); docker operations are isolated in `CliHarnessRunner`.

Measures these products as agentic loops driving a computer-use tool, not their native repo workflows — labeled as such in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)