### PR TITLE
Fail closed on task setup and expose runtime metadata

### DIFF
--- a/src/gym_anything/env.py
+++ b/src/gym_anything/env.py
@@ -33,6 +33,25 @@ logger = logging.getLogger(__name__)
 HOOK_TIMEOUT = int(os.environ.get("GYM_ANYTHING_HOOK_TIMEOUT", "1800"))
 
 
+def _require_hook_success(
+    runner: BaseRunner,
+    hook_name: str,
+    return_code: Any,
+    log_path: str,
+) -> None:
+    if return_code in (None, 0):
+        return
+    tail = ""
+    try:
+        tail = runner.exec_capture(
+            f"tail -n 80 {shlex.quote(log_path)} 2>/dev/null || true"
+        ).strip()
+    except Exception:
+        pass
+    detail = f"; output tail:\n{tail}" if tail else ""
+    raise RuntimeError(f"{hook_name} exited with code {return_code}{detail}")
+
+
 class GymAnythingEnv:
     """Unified environment wrapper exposing Gym-like API.
 
@@ -571,14 +590,24 @@ class GymAnythingEnv:
                     # Android uses sh instead of bash, and different paths
                     # Use longer timeout (180s) for Android hooks as game loading can take time
                     if self._platform_family() == "android":
-                        self._runner.exec(hook_cmd, timeout=180)
+                        return_code = self._runner.exec(hook_cmd, timeout=180)
                     # Windows uses PowerShell directly (hook_cmd already contains full PowerShell command)
                     elif self._platform_family() == "windows":
-                        self._runner.exec(hook_cmd, use_pty=False)
+                        return_code = self._runner.exec(hook_cmd, use_pty=False)
                     else:
                         # Use configurable timeout for pre_task hook (default 600s, can be overridden in task.json)
                         hook_timeout = self.task_spec.hooks.pre_task_timeout if self.task_spec.hooks else 600
-                        self._runner.exec(f"bash -lc {shlex.quote(hook_cmd)} > /tmp/task_pre_task.log 2>&1", use_pty=False, timeout=hook_timeout)
+                        return_code = self._runner.exec(
+                            f"bash -lc {shlex.quote(hook_cmd)} > /tmp/task_pre_task.log 2>&1",
+                            use_pty=False,
+                            timeout=hook_timeout,
+                        )
+                    _require_hook_success(
+                        self._runner,
+                        "pre_task hook",
+                        return_code,
+                        "/tmp/task_pre_task.log",
+                    )
                     self._capture_observation()
                     if self._reporter:
                         self._reporter.stage_done("pre_task_hook")
@@ -586,6 +615,7 @@ class GymAnythingEnv:
                     logger.warning("pre_task hook failed: %s", e)
                     if self._reporter:
                         self._reporter.stage_fail("pre_task_hook", str(e))
+                    raise
 
             # === TASK INIT SCRIPT ===
             if self.task_spec and self.task_spec.init.init_script:

--- a/src/gym_anything/verification/runner.py
+++ b/src/gym_anything/verification/runner.py
@@ -147,6 +147,16 @@ class VerifierRunner:
             runtime_info_getter = getattr(runner, "get_runtime_info", None)
             if callable(runtime_info_getter):
                 runtime_info = runtime_info_getter()
+                runtime_values = (
+                    runtime_info.to_dict()
+                    if hasattr(runtime_info, "to_dict")
+                    else asdict(runtime_info)
+                )
+                env_info.update({
+                    key: value
+                    for key, value in runtime_values.items()
+                    if value is not None
+                })
                 if runtime_info.container_name:
                     env_info["container"] = runtime_info.container_name
             elif hasattr(runner, "container_name"):

--- a/tests/test_verification_system.py
+++ b/tests/test_verification_system.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from unittest import mock
 
 from gym_anything.api import from_config
+from gym_anything.contracts import RunnerRuntimeInfo
+from gym_anything.env import _require_hook_success
 from gym_anything.specs import EnvSpec, TaskSpec
 from gym_anything.verification import verify_environment_dir
 from gym_anything.verification.pipeline import verify_task_pipeline
@@ -49,6 +51,21 @@ class VerificationSystemTests(unittest.TestCase):
                 "action": [{"type": "mouse"}],
             },
         )
+
+    def test_failed_task_setup_hook_is_fatal_and_includes_its_log(self) -> None:
+        runner = mock.Mock()
+        runner.exec_capture.return_value = "setup exploded\n"
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "(?s)pre_task hook exited with code 17.*setup exploded",
+        ):
+            _require_hook_success(
+                runner,
+                "pre_task hook",
+                17,
+                "/tmp/task_pre_task.log",
+            )
 
     def test_verify_environment_dir_succeeds_for_valid_task_layout(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -354,6 +371,59 @@ class VerificationSystemTests(unittest.TestCase):
             self.assertEqual(result.stage, "verifier")
             self.assertIsNotNone(result.verifier)
             self.assertFalse(result.verifier["passed"])
+
+    def test_program_verifier_receives_complete_runner_runtime_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            task_dir = root / "tasks" / "demo"
+            episode_dir = root / "episode"
+            task_dir.mkdir(parents=True)
+            episode_dir.mkdir()
+            (task_dir / "verifier.py").write_text(
+                "def verify(traj, env_info, task_info):\n"
+                "    return {\n"
+                "        'passed': True, 'score': 100,\n"
+                "        'seen_ssh_port': env_info.get('ssh_port'),\n"
+                "        'seen_ssh_user': env_info.get('ssh_user'),\n"
+                "        'seen_vnc_port': env_info.get('vnc_port'),\n"
+                "    }\n",
+                encoding="utf-8",
+            )
+            env_spec = EnvSpec.from_dict({
+                "id": "test-env",
+                "runner": "local",
+                "observation": [{"type": "rgb_screen", "resolution": [640, 480]}],
+                "action": [{"type": "mouse"}],
+            })
+            task_spec = TaskSpec.from_dict({
+                "id": "demo",
+                "success": {
+                    "mode": "program",
+                    "spec": {"program": "verifier.py::verify"},
+                },
+            })
+            runner = mock.Mock()
+            runner.get_runtime_info.return_value = RunnerRuntimeInfo(
+                platform_family="linux",
+                ssh_port=2222,
+                ssh_user="user",
+                ssh_password="password",
+                vnc_port=5901,
+            )
+
+            result = VerifierRunner().evaluate(
+                runner=runner,
+                env_spec=env_spec,
+                task_spec=task_spec,
+                episode_dir=episode_dir,
+                env_root=root,
+                task_root=task_dir,
+            )
+
+            self.assertTrue(result["passed"])
+            self.assertEqual(result["seen_ssh_port"], 2222)
+            self.assertEqual(result["seen_ssh_user"], "user")
+            self.assertEqual(result["seen_vnc_port"], 5901)
 
     def test_vlm_checklist_verifier_scores_trajectory_with_mocked_vlm(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- treat nonzero pre-task hooks as fatal and attach the guest log tail
- expose the runner's complete runtime metadata to program verifiers
- add regressions for setup failure propagation and SSH/VNC metadata

## Validation
- `PYTHONPATH=src pytest -q tests/test_verification_system.py` (16 passed)