### PR TITLE
Add native fast I/O to ModalNativeRunner

### DIFF
--- a/docs/content/docs/core/environments.mdx
+++ b/docs/content/docs/core/environments.mdx
@@ -38,8 +38,8 @@ env.close()
 
 ## Fast I/O Observations
 
-QEMU environments can opt into runner-native screenshot capture at environment
-creation time:
+Runners with a native fast-I/O backend can opt into in-memory screenshot capture
+at environment creation time:
 
 ```python
 env = from_config(
@@ -70,7 +70,12 @@ D-Bus display backend, set:
 export GYM_ANYTHING_QEMU_FAST_IO_BACKEND=dbus
 ```
 
-See [Runners](/core/runners) for the QEMU runtime requirements.
+See [Runners](/core/runners) for runner-specific runtime requirements.
+
+Modal Native uses a separate in-VM X11 backend: XDamage and MIT-SHM maintain
+the latest RGB frame, while XTest injects each keyboard or mouse action as one
+acknowledged batch. VNC remains available for interactive viewing but is not on
+the fast-mode screenshot or input path.
 
 ## What `step(...)` Does
 

--- a/docs/content/docs/core/runners.mdx
+++ b/docs/content/docs/core/runners.mdx
@@ -277,6 +277,18 @@ runner restarts from the new Image after creating a checkpoint so the first run
 has the same disk-only semantics as later restores. Modal VM Sandboxes do not
 provide VM memory snapshots, so `use_savevm=True` is unsupported.
 
+`fast_io=True` starts a native service next to the Xvnc server. A background
+XDamage listener captures changed frames through MIT-SHM into triple-buffered
+RGB memory, so screenshot requests return the latest completed frame instead of
+asking VNC to encode a new one. Keyboard and mouse actions are translated to one
+XTest event batch and acknowledged after a single `XSync`. The service is
+exposed through a persistent token-authenticated Modal TLS tunnel. A client
+running inside the Sandbox reads changed RGB frames directly from a seqlock-
+protected shared-memory triple buffer; calls made outside the Sandbox still
+include WAN transfer time. Fast mode requests at least four vCPUs so the RGB
+conversion can use four bounded row workers even when an environment asks for
+fewer; non-fast mode continues to honor the configured CPU count and use VNC.
+
 Requirements: `pip install "gym-anything[modal_native]"` and configured Modal
 credentials. Relevant environment variables:
 

--- a/src/gym_anything/runtime/runners/modal_native.py
+++ b/src/gym_anything/runtime/runners/modal_native.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import shlex
 import tarfile
 import tempfile
@@ -20,6 +21,7 @@ from ...config.presets import is_android_preset, is_windows_preset
 from ...contracts import RunnerRuntimeInfo
 from ...specs import EnvSpec, MountSpec
 from .base import BaseRunner
+from .modal_native_fast_io import FAST_IO_PORT, ModalNativeFastIOClient
 from .modal_native_image import MODAL_NATIVE_IMAGE_FINGERPRINT, build_modal_native_image
 from .vnc_utils import VNCConnection, VNCConnectionPool
 
@@ -116,6 +118,9 @@ class ModalNativeRunner(BaseRunner):
         self._sandbox = None
         self._vnc_tunnel: Optional[tuple[str, int]] = None
         self._vnc_pool: Optional[VNCConnectionPool] = None
+        self._fast_io_token = secrets.token_hex(32)
+        self._fast_io_tunnel: Optional[tuple[str, int]] = None
+        self._fast_io_client: Optional[ModalNativeFastIOClient] = None
         self._running = False
         self._checkpoint_cache_level: Optional[str] = None
         self._checkpoint_task_id: Optional[str] = None
@@ -177,9 +182,10 @@ class ModalNativeRunner(BaseRunner):
             )
 
     def _sandbox_create_kwargs(self) -> Dict[str, Any]:
+        cpu = max(self.cpu, 4.0) if self._fast_io else self.cpu
         kwargs: Dict[str, Any] = {
             "app": self._app,
-            "cpu": (self.cpu, self.cpu),
+            "cpu": (cpu, cpu),
             "memory": (self.memory_mb, self.memory_mb),
             "timeout": self.sandbox_timeout,
             "unencrypted_ports": [VNC_PORT],
@@ -187,12 +193,15 @@ class ModalNativeRunner(BaseRunner):
             "env": {
                 "GYM_ANYTHING_VNC_GEOMETRY": f"{self.resolution[0]}x{self.resolution[1]}",
                 "GYM_ANYTHING_VNC_PASSWORD": self.vnc_password,
+                "GYM_ANYTHING_FAST_IO_TOKEN": self._fast_io_token,
             },
             "tags": {
                 "gym-anything-runner": "modal-native",
                 "gym-anything-env": re.sub(r"[^A-Za-z0-9_.-]", "_", self.spec.id)[:64],
             },
         }
+        if self._fast_io:
+            kwargs["encrypted_ports"] = [FAST_IO_PORT]
         if self.spec.resources.net is False:
             kwargs["outbound_cidr_allowlist"] = []
             kwargs["outbound_domain_allowlist"] = []
@@ -220,6 +229,9 @@ class ModalNativeRunner(BaseRunner):
         self._vnc_tunnel = tuple(tunnel.tcp_socket)
         self.vnc_url = f"vnc://{self._vnc_tunnel[0]}:{self._vnc_tunnel[1]}"
         self.vnc_port = int(self._vnc_tunnel[1])
+        if self._fast_io:
+            fast_io_tunnel = self._sandbox.tunnels()[FAST_IO_PORT]
+            self._fast_io_tunnel = tuple(fast_io_tunnel.tls_socket)
         self._report_done("modal_native_sandbox", self.instance_name or "")
 
     def _start_with_image(self, image=None, seed: Optional[int] = None) -> None:
@@ -231,6 +243,8 @@ class ModalNativeRunner(BaseRunner):
             self._wait_for_desktop()
             self._setup_mounts()
             self._connect_vnc()
+            if self._fast_io:
+                self._connect_fast_io()
             self._running = True
         except BaseException:
             self.stop()
@@ -242,6 +256,13 @@ class ModalNativeRunner(BaseRunner):
         self._start_with_image(seed=seed)
 
     def stop(self) -> None:
+        fast_io_client, self._fast_io_client = self._fast_io_client, None
+        if fast_io_client is not None:
+            try:
+                fast_io_client.close()
+            except Exception as exc:
+                self._report_log(f"Modal Native fast-I/O cleanup failed: {exc}")
+
         pool, self._vnc_pool = self._vnc_pool, None
         if pool is not None:
             try:
@@ -257,6 +278,7 @@ class ModalNativeRunner(BaseRunner):
                 self._report_log(f"Modal Native Sandbox termination failed: {exc}")
 
         self._running = False
+        self._fast_io_tunnel = None
         self._vnc_tunnel = None
         self.vnc_port = None
         self.vnc_url = None
@@ -397,7 +419,36 @@ class ModalNativeRunner(BaseRunner):
             raise RuntimeError("Modal Native VNC connection failed")
         return connection
 
+    def _connect_fast_io(self) -> None:
+        if self._fast_io_tunnel is None:
+            raise RuntimeError("Modal Native fast-I/O tunnel is unavailable")
+        code = self.exec(
+            "systemctl restart ga-fast-io.service",
+            use_pty=False,
+            timeout=30,
+        )
+        if code != 0:
+            raise RuntimeError("Could not start the Modal Native fast-I/O service")
+        host, port = self._fast_io_tunnel
+        client = ModalNativeFastIOClient(
+            host,
+            port,
+            self._fast_io_token,
+            self.resolution,
+            timeout=30.0,
+        )
+        client.connect(retry_count=30, retry_delay=1.0)
+        self._fast_io_client = client
+
+    def _native_fast_io(self) -> ModalNativeFastIOClient:
+        if self._fast_io_client is None:
+            raise RuntimeError("Modal Native fast I/O is not initialized")
+        return self._fast_io_client
+
     def inject_action(self, action: Dict[str, Any]) -> None:
+        if self._fast_io:
+            self._native_fast_io().inject_action(action)
+            return
         connection = self._vnc_connection()
         mouse = action.get("mouse") or {}
         if "left_click" in mouse:
@@ -471,10 +522,17 @@ class ModalNativeRunner(BaseRunner):
         }
 
     def capture_screenshot(self, host_path) -> bool:
+        if self._fast_io:
+            destination = Path(host_path)
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            self.capture_screenshot_image().save(destination, "PNG")
+            return True
         data = self._vnc_connection().capture_screenshot(Path(host_path))
         return data is not None
 
     def capture_screenshot_image(self):
+        if self._fast_io:
+            return self._native_fast_io().capture_image()
         import io
 
         from PIL import Image

--- a/src/gym_anything/runtime/runners/modal_native_assets/bootstrap.sh
+++ b/src/gym_anything/runtime/runners/modal_native_assets/bootstrap.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 geometry="${GYM_ANYTHING_VNC_GEOMETRY:-1920x1080}"
 password="${GYM_ANYTHING_VNC_PASSWORD:-password}"
+fast_io_token="${GYM_ANYTHING_FAST_IO_TOKEN:?GYM_ANYTHING_FAST_IO_TOKEN is required}"
 
 install -d -m 0755 /run/gym-anything /etc/gym-anything
 install -d -o ga -g ga -m 0700 /home/ga/.vnc
@@ -10,6 +11,8 @@ printf '%s\n' "$password" | vncpasswd -f > /home/ga/.vnc/passwd
 chown ga:ga /home/ga/.vnc/passwd
 chmod 0600 /home/ga/.vnc/passwd
 printf 'GA_VNC_GEOMETRY=%s\n' "$geometry" > /etc/gym-anything/vnc.env
+umask 077
+printf 'GA_FAST_IO_TOKEN=%s\n' "$fast_io_token" > /etc/gym-anything/fast-io.env
 
 rm -f /run/gym-anything/systemd.pid
 /usr/bin/unshare --fork --pid --mount --mount-proc /usr/local/sbin/ga-systemd-init &

--- a/src/gym_anything/runtime/runners/modal_native_assets/fast_io_server.c
+++ b/src/gym_anything/runtime/runners/modal_native_assets/fast_io_server.c
@@ -1,0 +1,1106 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/extensions/XShm.h>
+#include <X11/extensions/XTest.h>
+#include <X11/extensions/Xdamage.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <omp.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ipc.h>
+#include <sys/mman.h>
+#include <sys/shm.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#if defined(__x86_64__) || defined(__i386__)
+#include <tmmintrin.h>
+#endif
+
+#define GA_MAGIC 0x47414649U
+#define GA_VERSION 1U
+
+#define OP_HELLO 1U
+#define OP_PING 2U
+#define OP_SCREENSHOT 3U
+#define OP_ACTION 4U
+
+#define EVENT_MOTION 1U
+#define EVENT_BUTTON 2U
+#define EVENT_KEY 3U
+
+#define FRAME_DATA_FOLLOWS 1U
+#define CAPABILITY_NATIVE_X11 1U
+
+#define STATUS_OK 0U
+#define STATUS_PROTOCOL 1U
+#define STATUS_AUTH 2U
+#define STATUS_INPUT 3U
+#define STATUS_INTERNAL 4U
+
+#define REQUEST_HEADER_SIZE 12U
+#define RESPONSE_HEADER_SIZE 16U
+#define SCREENSHOT_META_SIZE 40U
+#define WIRE_EVENT_SIZE 16U
+#define FRAME_SLOTS 3
+#define MAX_EVENTS 4096U
+#define MAX_REQUEST_SIZE (4U + MAX_EVENTS * WIRE_EVENT_SIZE)
+#define LOCAL_FRAME_PATH "/dev/shm/gym-anything-modal-native-fast-io"
+#define LOCAL_HEADER_SIZE 4096U
+#define LOCAL_CURRENT_OFFSET 24U
+#define LOCAL_SLOT_META_OFFSET 32U
+#define LOCAL_SLOT_META_SIZE 32U
+
+typedef struct {
+    uint8_t *rgb;
+    unsigned int readers;
+    uint64_t id;
+    uint64_t captured_ns;
+    uint64_t capture_elapsed_ns;
+} FrameSlot;
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t changed;
+    FrameSlot slots[FRAME_SLOTS];
+    int current;
+    int next_slot;
+    int ready;
+    int stopping;
+    unsigned int width;
+    unsigned int height;
+    unsigned int stride;
+    char error[256];
+} FrameCache;
+
+typedef struct {
+    uint8_t kind;
+    uint8_t down;
+    uint32_t code;
+    int32_t x;
+    int32_t y;
+    KeyCode keycode;
+} InputEvent;
+
+static FrameCache frame_cache = {
+    .mutex = PTHREAD_MUTEX_INITIALIZER,
+    .changed = PTHREAD_COND_INITIALIZER,
+    .current = -1,
+};
+static pthread_mutex_t input_mutex = PTHREAD_MUTEX_INITIALIZER;
+static Display *input_display = NULL;
+static int input_screen = 0;
+static const char *auth_token = NULL;
+static uint8_t *local_frames = NULL;
+static size_t local_frames_size = 0;
+static volatile sig_atomic_t running = 1;
+static int listen_fd = -1;
+
+static uint16_t read_u16(const uint8_t *data) {
+    uint16_t value;
+    memcpy(&value, data, sizeof(value));
+    return ntohs(value);
+}
+
+static uint32_t read_u32(const uint8_t *data) {
+    uint32_t value;
+    memcpy(&value, data, sizeof(value));
+    return ntohl(value);
+}
+
+static uint64_t read_u64(const uint8_t *data) {
+    return ((uint64_t)read_u32(data) << 32U) | read_u32(data + 4);
+}
+
+static void write_u16(uint8_t *data, uint16_t value) {
+    value = htons(value);
+    memcpy(data, &value, sizeof(value));
+}
+
+static void write_u32(uint8_t *data, uint32_t value) {
+    value = htonl(value);
+    memcpy(data, &value, sizeof(value));
+}
+
+static void write_u64(uint8_t *data, uint64_t value) {
+    write_u32(data, (uint32_t)(value >> 32U));
+    write_u32(data + 4, (uint32_t)value);
+}
+
+static void write_native_u32(uint8_t *data, uint32_t value) {
+    memcpy(data, &value, sizeof(value));
+}
+
+static void write_native_u64(uint8_t *data, uint64_t value) {
+    memcpy(data, &value, sizeof(value));
+}
+
+static uint64_t load_local_u64(size_t offset) {
+    return __atomic_load_n((uint64_t *)(local_frames + offset), __ATOMIC_ACQUIRE);
+}
+
+static void store_local_u64(size_t offset, uint64_t value) {
+    __atomic_store_n((uint64_t *)(local_frames + offset), value, __ATOMIC_RELEASE);
+}
+
+static uint64_t monotonic_ns(void) {
+    struct timespec now;
+#ifdef CLOCK_MONOTONIC_RAW
+    clock_gettime(CLOCK_MONOTONIC_RAW, &now);
+#else
+    clock_gettime(CLOCK_MONOTONIC, &now);
+#endif
+    return (uint64_t)now.tv_sec * 1000000000ULL + (uint64_t)now.tv_nsec;
+}
+
+static int read_full(int fd, void *buffer, size_t size) {
+    uint8_t *cursor = buffer;
+    while (size > 0) {
+        ssize_t count = recv(fd, cursor, size, 0);
+        if (count == 0) {
+            return 0;
+        }
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        cursor += (size_t)count;
+        size -= (size_t)count;
+    }
+    return 1;
+}
+
+static int write_full(int fd, const void *buffer, size_t size) {
+    const uint8_t *cursor = buffer;
+    while (size > 0) {
+        ssize_t count = send(fd, cursor, size, MSG_NOSIGNAL);
+        if (count == 0) {
+            return -1;
+        }
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return -1;
+        }
+        cursor += (size_t)count;
+        size -= (size_t)count;
+    }
+    return 0;
+}
+
+static int send_header(
+    int fd,
+    uint16_t opcode,
+    uint32_t status,
+    uint32_t payload_size
+) {
+    uint8_t header[RESPONSE_HEADER_SIZE];
+    write_u32(header, GA_MAGIC);
+    write_u16(header + 4, GA_VERSION);
+    write_u16(header + 6, opcode);
+    write_u32(header + 8, status);
+    write_u32(header + 12, payload_size);
+    return write_full(fd, header, sizeof(header));
+}
+
+static int send_response(
+    int fd,
+    uint16_t opcode,
+    uint32_t status,
+    const void *payload,
+    uint32_t payload_size
+) {
+    if (send_header(fd, opcode, status, payload_size) < 0) {
+        return -1;
+    }
+    if (payload_size > 0 && write_full(fd, payload, payload_size) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static int send_error(int fd, uint16_t opcode, uint32_t status, const char *message) {
+    size_t length = strlen(message);
+    if (length > UINT32_MAX) {
+        length = UINT32_MAX;
+    }
+    return send_response(fd, opcode, status, message, (uint32_t)length);
+}
+
+static void set_capture_error(const char *message) {
+    pthread_mutex_lock(&frame_cache.mutex);
+    snprintf(frame_cache.error, sizeof(frame_cache.error), "%s", message);
+    frame_cache.ready = -1;
+    pthread_cond_broadcast(&frame_cache.changed);
+    pthread_mutex_unlock(&frame_cache.mutex);
+}
+
+static unsigned int component_shift(unsigned long mask) {
+    unsigned int shift = 0;
+    if (mask == 0) {
+        return 0;
+    }
+    while ((mask & 1UL) == 0) {
+        mask >>= 1U;
+        shift++;
+    }
+    return shift;
+}
+
+static uint8_t scale_component(unsigned long pixel, unsigned long mask) {
+    if (mask == 0) {
+        return 0;
+    }
+    unsigned int shift = component_shift(mask);
+    unsigned long maximum = mask >> shift;
+    unsigned long value = (pixel & mask) >> shift;
+    return (uint8_t)((value * 255UL + maximum / 2UL) / maximum);
+}
+
+static int conversion_threads(void) {
+    long processors = sysconf(_SC_NPROCESSORS_ONLN);
+    if (processors < 1) {
+        return 1;
+    }
+    return processors > 4 ? 4 : (int)processors;
+}
+
+static unsigned long image_pixel(const uint8_t *source, int bytes, int byte_order) {
+    unsigned long pixel = 0;
+    if (byte_order == LSBFirst) {
+        for (int index = 0; index < bytes; index++) {
+            pixel |= (unsigned long)source[index] << (8U * (unsigned int)index);
+        }
+    } else {
+        for (int index = 0; index < bytes; index++) {
+            pixel = (pixel << 8U) | source[index];
+        }
+    }
+    return pixel;
+}
+
+#if defined(__x86_64__) || defined(__i386__)
+__attribute__((target("ssse3")))
+static void convert_xrgb_ssse3(
+    const XImage *image,
+    uint8_t *destination,
+    int source_is_bgr,
+    unsigned int first_row,
+    unsigned int last_row
+) {
+    const __m128i shuffle = source_is_bgr
+        ? _mm_setr_epi8(
+            2, 1, 0, 6, 5, 4, 10, 9, 8, 14, 13, 12,
+            (char)0x80, (char)0x80, (char)0x80, (char)0x80
+        )
+        : _mm_setr_epi8(
+            0, 1, 2, 4, 5, 6, 8, 9, 10, 12, 13, 14,
+            (char)0x80, (char)0x80, (char)0x80, (char)0x80
+        );
+    const unsigned int width = (unsigned int)image->width;
+    for (unsigned int y = first_row; y < last_row; y++) {
+        const uint8_t *source =
+            (const uint8_t *)image->data + (size_t)y * image->bytes_per_line;
+        uint8_t *target = destination + (size_t)y * width * 3U;
+        unsigned int x = 0;
+        for (; x + 16U <= width; x += 16U) {
+            __m128i first = _mm_shuffle_epi8(
+                _mm_loadu_si128((const __m128i *)(source + x * 4U)),
+                shuffle
+            );
+            __m128i second = _mm_shuffle_epi8(
+                _mm_loadu_si128((const __m128i *)(source + x * 4U + 16U)),
+                shuffle
+            );
+            __m128i third = _mm_shuffle_epi8(
+                _mm_loadu_si128((const __m128i *)(source + x * 4U + 32U)),
+                shuffle
+            );
+            __m128i fourth = _mm_shuffle_epi8(
+                _mm_loadu_si128((const __m128i *)(source + x * 4U + 48U)),
+                shuffle
+            );
+            _mm_storeu_si128(
+                (__m128i *)(target + x * 3U),
+                _mm_or_si128(first, _mm_slli_si128(second, 12))
+            );
+            _mm_storeu_si128(
+                (__m128i *)(target + x * 3U + 16U),
+                _mm_or_si128(
+                    _mm_srli_si128(second, 4),
+                    _mm_slli_si128(third, 8)
+                )
+            );
+            _mm_storeu_si128(
+                (__m128i *)(target + x * 3U + 32U),
+                _mm_or_si128(
+                    _mm_srli_si128(third, 8),
+                    _mm_slli_si128(fourth, 4)
+                )
+            );
+        }
+        for (; x + 4U <= width; x += 4U) {
+            __m128i pixels = _mm_loadu_si128((const __m128i *)(source + x * 4U));
+            __m128i rgb = _mm_shuffle_epi8(pixels, shuffle);
+            _mm_storel_epi64((__m128i *)(target + x * 3U), rgb);
+            uint32_t tail = (uint32_t)_mm_cvtsi128_si32(_mm_srli_si128(rgb, 8));
+            memcpy(target + x * 3U + 8U, &tail, sizeof(tail));
+        }
+        for (; x < width; x++) {
+            if (source_is_bgr) {
+                target[x * 3U] = source[x * 4U + 2U];
+                target[x * 3U + 1U] = source[x * 4U + 1U];
+                target[x * 3U + 2U] = source[x * 4U];
+            } else {
+                target[x * 3U] = source[x * 4U];
+                target[x * 3U + 1U] = source[x * 4U + 1U];
+                target[x * 3U + 2U] = source[x * 4U + 2U];
+            }
+        }
+    }
+}
+#endif
+
+static void convert_to_rgb(const XImage *image, uint8_t *destination) {
+    const unsigned int width = (unsigned int)image->width;
+    const unsigned int height = (unsigned int)image->height;
+    const int bytes_per_pixel = (image->bits_per_pixel + 7) / 8;
+    const int threads = conversion_threads();
+
+    int source_is_bgr =
+        image->red_mask == 0x00ff0000UL &&
+        image->green_mask == 0x0000ff00UL &&
+        image->blue_mask == 0x000000ffUL;
+    int source_is_rgb =
+        image->red_mask == 0x000000ffUL &&
+        image->green_mask == 0x0000ff00UL &&
+        image->blue_mask == 0x00ff0000UL;
+    if (image->bits_per_pixel == 32 && image->byte_order == LSBFirst &&
+        (source_is_bgr || source_is_rgb)) {
+#if defined(__x86_64__) || defined(__i386__)
+        if (__builtin_cpu_supports("ssse3")) {
+            #pragma omp parallel num_threads(threads)
+            {
+                unsigned int thread = (unsigned int)omp_get_thread_num();
+                unsigned int count = (unsigned int)omp_get_num_threads();
+                unsigned int first_row = height * thread / count;
+                unsigned int last_row = height * (thread + 1U) / count;
+                convert_xrgb_ssse3(
+                    image,
+                    destination,
+                    source_is_bgr,
+                    first_row,
+                    last_row
+                );
+            }
+            return;
+        }
+#endif
+        #pragma omp parallel for num_threads(threads) schedule(static)
+        for (unsigned int y = 0; y < height; y++) {
+            const uint8_t *source =
+                (const uint8_t *)image->data + (size_t)y * image->bytes_per_line;
+            uint8_t *target = destination + (size_t)y * width * 3U;
+            for (unsigned int x = 0; x < width; x++) {
+                target[x * 3U] = source[x * 4U + (source_is_bgr ? 2U : 0U)];
+                target[x * 3U + 1U] = source[x * 4U + 1U];
+                target[x * 3U + 2U] = source[x * 4U + (source_is_bgr ? 0U : 2U)];
+            }
+        }
+        return;
+    }
+
+    #pragma omp parallel for num_threads(threads) schedule(static)
+    for (unsigned int y = 0; y < height; y++) {
+        const uint8_t *source =
+            (const uint8_t *)image->data + (size_t)y * image->bytes_per_line;
+        uint8_t *target = destination + (size_t)y * width * 3U;
+        for (unsigned int x = 0; x < width; x++) {
+            unsigned long pixel = image_pixel(
+                source + (size_t)x * (size_t)bytes_per_pixel,
+                bytes_per_pixel,
+                image->byte_order
+            );
+            target[x * 3U] = scale_component(pixel, image->red_mask);
+            target[x * 3U + 1U] = scale_component(pixel, image->green_mask);
+            target[x * 3U + 2U] = scale_component(pixel, image->blue_mask);
+        }
+    }
+}
+
+static int writable_frame_slot(void) {
+    pthread_mutex_lock(&frame_cache.mutex);
+    for (;;) {
+        for (int offset = 0; offset < FRAME_SLOTS; offset++) {
+            int index = (frame_cache.next_slot + offset) % FRAME_SLOTS;
+            if (index != frame_cache.current && frame_cache.slots[index].readers == 0) {
+                frame_cache.next_slot = (index + 1) % FRAME_SLOTS;
+                pthread_mutex_unlock(&frame_cache.mutex);
+                return index;
+            }
+        }
+        if (frame_cache.stopping) {
+            pthread_mutex_unlock(&frame_cache.mutex);
+            return -1;
+        }
+        pthread_cond_wait(&frame_cache.changed, &frame_cache.mutex);
+    }
+}
+
+static int initialize_local_frames(
+    unsigned int width,
+    unsigned int height,
+    unsigned int stride
+) {
+    size_t frame_size = (size_t)stride * height;
+    if (frame_size > (SIZE_MAX - LOCAL_HEADER_SIZE) / FRAME_SLOTS) {
+        return -1;
+    }
+    local_frames_size = LOCAL_HEADER_SIZE + frame_size * FRAME_SLOTS;
+    int fd = open(LOCAL_FRAME_PATH, O_CREAT | O_RDWR, 0600);
+    if (fd < 0) {
+        return -1;
+    }
+    if (fchmod(fd, 0600) < 0 || ftruncate(fd, (off_t)local_frames_size) < 0) {
+        close(fd);
+        return -1;
+    }
+    local_frames = mmap(
+        NULL,
+        local_frames_size,
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED,
+        fd,
+        0
+    );
+    close(fd);
+    if (local_frames == MAP_FAILED) {
+        local_frames = NULL;
+        return -1;
+    }
+    memset(local_frames, 0, LOCAL_HEADER_SIZE);
+    memcpy(local_frames, "GAFS", 4);
+    write_native_u32(local_frames + 4, GA_VERSION);
+    write_native_u32(local_frames + 8, width);
+    write_native_u32(local_frames + 12, height);
+    write_native_u32(local_frames + 16, stride);
+    write_native_u32(local_frames + 20, FRAME_SLOTS);
+    store_local_u64(LOCAL_CURRENT_OFFSET, UINT64_MAX);
+    for (int index = 0; index < FRAME_SLOTS; index++) {
+        frame_cache.slots[index].rgb =
+            local_frames + LOCAL_HEADER_SIZE + (size_t)index * frame_size;
+    }
+    return 0;
+}
+
+static int capture_frame(Display *display, Drawable root, XImage *image) {
+    int slot_index = writable_frame_slot();
+    if (slot_index < 0) {
+        return -1;
+    }
+    size_t local_meta =
+        LOCAL_SLOT_META_OFFSET + (size_t)slot_index * LOCAL_SLOT_META_SIZE;
+    uint64_t local_sequence = 0;
+    if (local_frames != NULL) {
+        local_sequence = load_local_u64(local_meta);
+        if (local_sequence & 1U) {
+            local_sequence++;
+        }
+        store_local_u64(local_meta, local_sequence + 1U);
+    }
+    uint64_t started_ns = monotonic_ns();
+    if (!XShmGetImage(display, root, image, 0, 0, AllPlanes)) {
+        if (local_frames != NULL) {
+            store_local_u64(local_meta, local_sequence + 2U);
+        }
+        set_capture_error("XShmGetImage failed");
+        return -1;
+    }
+    convert_to_rgb(image, frame_cache.slots[slot_index].rgb);
+    uint64_t captured_ns = monotonic_ns();
+    uint64_t capture_elapsed_ns = captured_ns - started_ns;
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    uint64_t next_id = frame_cache.current < 0
+        ? 1
+        : frame_cache.slots[frame_cache.current].id + 1;
+    frame_cache.slots[slot_index].id = next_id;
+    frame_cache.slots[slot_index].captured_ns = captured_ns;
+    frame_cache.slots[slot_index].capture_elapsed_ns = capture_elapsed_ns;
+    if (local_frames != NULL) {
+        write_native_u64(local_frames + local_meta + 8, next_id);
+        write_native_u64(local_frames + local_meta + 16, captured_ns);
+        write_native_u64(local_frames + local_meta + 24, capture_elapsed_ns);
+        store_local_u64(local_meta, local_sequence + 2U);
+        store_local_u64(LOCAL_CURRENT_OFFSET, (uint64_t)slot_index);
+    }
+    frame_cache.current = slot_index;
+    frame_cache.ready = 1;
+    pthread_cond_broadcast(&frame_cache.changed);
+    pthread_mutex_unlock(&frame_cache.mutex);
+    return 0;
+}
+
+static void destroy_shm_image(
+    Display *display,
+    XImage *image,
+    XShmSegmentInfo *shm_info,
+    int attached
+) {
+    if (attached && display != NULL && image != NULL) {
+        XShmDetach(display, shm_info);
+        XSync(display, False);
+    }
+    if (shm_info->shmaddr != NULL && shm_info->shmaddr != (char *)-1) {
+        shmdt(shm_info->shmaddr);
+    }
+    if (image != NULL) {
+        image->data = NULL;
+        XDestroyImage(image);
+    }
+}
+
+static void *capture_thread_main(void *unused) {
+    (void)unused;
+    Display *display = XOpenDisplay(NULL);
+    if (display == NULL) {
+        set_capture_error("could not open the X11 display for capture");
+        return NULL;
+    }
+    if (!XShmQueryExtension(display)) {
+        set_capture_error("the X11 display does not support MIT-SHM");
+        XCloseDisplay(display);
+        return NULL;
+    }
+
+    int damage_event_base = 0;
+    int damage_error_base = 0;
+    if (!XDamageQueryExtension(display, &damage_event_base, &damage_error_base)) {
+        set_capture_error("the X11 display does not support XDamage");
+        XCloseDisplay(display);
+        return NULL;
+    }
+
+    int screen = DefaultScreen(display);
+    Window root = RootWindow(display, screen);
+    XWindowAttributes attributes;
+    if (!XGetWindowAttributes(display, root, &attributes)) {
+        set_capture_error("could not read the X11 root-window geometry");
+        XCloseDisplay(display);
+        return NULL;
+    }
+
+    XShmSegmentInfo shm_info;
+    memset(&shm_info, 0, sizeof(shm_info));
+    shm_info.shmid = -1;
+    shm_info.shmaddr = (char *)-1;
+    XImage *image = XShmCreateImage(
+        display,
+        attributes.visual,
+        (unsigned int)attributes.depth,
+        ZPixmap,
+        NULL,
+        &shm_info,
+        (unsigned int)attributes.width,
+        (unsigned int)attributes.height
+    );
+    if (image == NULL) {
+        set_capture_error("XShmCreateImage failed");
+        XCloseDisplay(display);
+        return NULL;
+    }
+
+    size_t image_size = (size_t)image->bytes_per_line * (size_t)image->height;
+    shm_info.shmid = shmget(IPC_PRIVATE, image_size, IPC_CREAT | 0600);
+    if (shm_info.shmid < 0) {
+        set_capture_error("could not allocate the XShm segment");
+        destroy_shm_image(display, image, &shm_info, 0);
+        XCloseDisplay(display);
+        return NULL;
+    }
+    shm_info.shmaddr = shmat(shm_info.shmid, NULL, 0);
+    if (shm_info.shmaddr == (char *)-1) {
+        set_capture_error("could not attach the XShm segment");
+        shmctl(shm_info.shmid, IPC_RMID, NULL);
+        destroy_shm_image(display, image, &shm_info, 0);
+        XCloseDisplay(display);
+        return NULL;
+    }
+    image->data = shm_info.shmaddr;
+    shm_info.readOnly = False;
+    if (!XShmAttach(display, &shm_info)) {
+        set_capture_error("could not attach XShm to the X server");
+        shmctl(shm_info.shmid, IPC_RMID, NULL);
+        destroy_shm_image(display, image, &shm_info, 0);
+        XCloseDisplay(display);
+        return NULL;
+    }
+    XSync(display, False);
+    shmctl(shm_info.shmid, IPC_RMID, NULL);
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    frame_cache.width = (unsigned int)attributes.width;
+    frame_cache.height = (unsigned int)attributes.height;
+    frame_cache.stride = (unsigned int)attributes.width * 3U;
+    if (initialize_local_frames(
+        frame_cache.width,
+        frame_cache.height,
+        frame_cache.stride
+    ) < 0) {
+        unlink(LOCAL_FRAME_PATH);
+        fprintf(stderr, "local shared-memory frames unavailable; using private buffers\n");
+        size_t rgb_size = (size_t)frame_cache.stride * frame_cache.height;
+        for (int index = 0; index < FRAME_SLOTS; index++) {
+            frame_cache.slots[index].rgb = malloc(rgb_size);
+            if (frame_cache.slots[index].rgb != NULL) {
+                continue;
+            }
+            snprintf(
+                frame_cache.error,
+                sizeof(frame_cache.error),
+                "could not allocate RGB frame buffers"
+            );
+            frame_cache.ready = -1;
+            pthread_cond_broadcast(&frame_cache.changed);
+            pthread_mutex_unlock(&frame_cache.mutex);
+            destroy_shm_image(display, image, &shm_info, 1);
+            XCloseDisplay(display);
+            return NULL;
+        }
+    }
+    pthread_mutex_unlock(&frame_cache.mutex);
+
+    Damage damage = XDamageCreate(display, root, XDamageReportNonEmpty);
+    XSync(display, False);
+    if (capture_frame(display, root, image) < 0) {
+        XDamageDestroy(display, damage);
+        destroy_shm_image(display, image, &shm_info, 1);
+        XCloseDisplay(display);
+        return NULL;
+    }
+
+    while (running) {
+        XEvent event;
+        XNextEvent(display, &event);
+        if (event.type != damage_event_base + XDamageNotify) {
+            continue;
+        }
+        XDamageSubtract(display, damage, None, None);
+        XSync(display, False);
+        if (capture_frame(display, root, image) < 0) {
+            break;
+        }
+    }
+
+    XDamageDestroy(display, damage);
+    destroy_shm_image(display, image, &shm_info, 1);
+    XCloseDisplay(display);
+    return NULL;
+}
+
+static int token_matches(const uint8_t *candidate, uint32_t length) {
+    size_t expected_length = strlen(auth_token);
+    unsigned int difference = (unsigned int)(expected_length ^ length);
+    size_t maximum = expected_length > length ? expected_length : length;
+    for (size_t index = 0; index < maximum; index++) {
+        uint8_t expected = index < expected_length ? (uint8_t)auth_token[index] : 0;
+        uint8_t received = index < length ? candidate[index] : 0;
+        difference |= expected ^ received;
+    }
+    return difference == 0;
+}
+
+static int handle_hello(int fd, uint16_t opcode, const uint8_t *payload, uint32_t length) {
+    if (!token_matches(payload, length)) {
+        send_error(fd, opcode, STATUS_AUTH, "fast-I/O authentication failed");
+        return -1;
+    }
+
+    uint8_t response[16];
+    pthread_mutex_lock(&frame_cache.mutex);
+    write_u32(response, frame_cache.width);
+    write_u32(response + 4, frame_cache.height);
+    pthread_mutex_unlock(&frame_cache.mutex);
+    write_u32(response + 8, 3);
+    write_u32(response + 12, CAPABILITY_NATIVE_X11);
+    return send_response(fd, opcode, STATUS_OK, response, sizeof(response));
+}
+
+static int handle_screenshot(
+    int fd,
+    uint16_t opcode,
+    const uint8_t *payload,
+    uint32_t length
+) {
+    if (length != 8) {
+        return send_error(fd, opcode, STATUS_PROTOCOL, "invalid screenshot request");
+    }
+    uint64_t client_frame_id = read_u64(payload);
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    while (frame_cache.ready == 0) {
+        pthread_cond_wait(&frame_cache.changed, &frame_cache.mutex);
+    }
+    if (frame_cache.ready < 0 || frame_cache.current < 0) {
+        char message[256];
+        snprintf(message, sizeof(message), "%s", frame_cache.error);
+        pthread_mutex_unlock(&frame_cache.mutex);
+        return send_error(fd, opcode, STATUS_INTERNAL, message);
+    }
+    int slot_index = frame_cache.current;
+    FrameSlot *slot = &frame_cache.slots[slot_index];
+    slot->readers++;
+    unsigned int width = frame_cache.width;
+    unsigned int height = frame_cache.height;
+    unsigned int stride = frame_cache.stride;
+    uint64_t frame_id = slot->id;
+    uint64_t captured_ns = slot->captured_ns;
+    uint64_t capture_elapsed_ns = slot->capture_elapsed_ns;
+    int include_data = client_frame_id != frame_id;
+    pthread_mutex_unlock(&frame_cache.mutex);
+
+    uint8_t metadata[SCREENSHOT_META_SIZE];
+    write_u32(metadata, width);
+    write_u32(metadata + 4, height);
+    write_u32(metadata + 8, stride);
+    write_u32(metadata + 12, include_data ? FRAME_DATA_FOLLOWS : 0);
+    write_u64(metadata + 16, frame_id);
+    write_u64(metadata + 24, captured_ns);
+    write_u64(metadata + 32, capture_elapsed_ns);
+
+    uint64_t frame_bytes = (uint64_t)stride * height;
+    uint64_t response_bytes = SCREENSHOT_META_SIZE + (include_data ? frame_bytes : 0);
+    int result = -1;
+    if (response_bytes <= UINT32_MAX &&
+        send_header(fd, opcode, STATUS_OK, (uint32_t)response_bytes) == 0 &&
+        write_full(fd, metadata, sizeof(metadata)) == 0 &&
+        (!include_data || write_full(fd, slot->rgb, (size_t)frame_bytes) == 0)) {
+        result = 0;
+    }
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    slot->readers--;
+    pthread_cond_broadcast(&frame_cache.changed);
+    pthread_mutex_unlock(&frame_cache.mutex);
+    return result;
+}
+
+static int handle_action(
+    int fd,
+    uint16_t opcode,
+    const uint8_t *payload,
+    uint32_t length
+) {
+    if (length < 4) {
+        return send_error(fd, opcode, STATUS_PROTOCOL, "invalid action request");
+    }
+    uint32_t count = read_u32(payload);
+    if (count > MAX_EVENTS || length != 4U + count * WIRE_EVENT_SIZE) {
+        return send_error(fd, opcode, STATUS_PROTOCOL, "invalid action event batch");
+    }
+
+    InputEvent *events = calloc(count, sizeof(*events));
+    if (count > 0 && events == NULL) {
+        return send_error(fd, opcode, STATUS_INTERNAL, "could not allocate input batch");
+    }
+    for (uint32_t index = 0; index < count; index++) {
+        const uint8_t *wire = payload + 4U + index * WIRE_EVENT_SIZE;
+        events[index].kind = wire[0];
+        events[index].down = wire[1];
+        events[index].code = read_u32(wire + 4);
+        events[index].x = (int32_t)read_u32(wire + 8);
+        events[index].y = (int32_t)read_u32(wire + 12);
+    }
+
+    char error[160] = "";
+    pthread_mutex_lock(&input_mutex);
+    for (uint32_t index = 0; index < count; index++) {
+        InputEvent *event = &events[index];
+        if (event->kind == EVENT_MOTION) {
+            if (event->x < 0) {
+                event->x = 0;
+            } else if ((unsigned int)event->x >= frame_cache.width) {
+                event->x = (int32_t)frame_cache.width - 1;
+            }
+            if (event->y < 0) {
+                event->y = 0;
+            } else if ((unsigned int)event->y >= frame_cache.height) {
+                event->y = (int32_t)frame_cache.height - 1;
+            }
+        } else if (event->kind == EVENT_BUTTON) {
+            if (event->code < 1 || event->code > 7 || event->down > 1) {
+                snprintf(error, sizeof(error), "invalid X11 button event at index %u", index);
+                break;
+            }
+        } else if (event->kind == EVENT_KEY) {
+            if (event->down > 1) {
+                snprintf(error, sizeof(error), "invalid X11 key event at index %u", index);
+                break;
+            }
+            event->keycode = XKeysymToKeycode(input_display, (KeySym)event->code);
+            if (event->keycode == 0) {
+                snprintf(
+                    error,
+                    sizeof(error),
+                    "X11 keyboard map has no keycode for keysym 0x%08x",
+                    event->code
+                );
+                break;
+            }
+        } else {
+            snprintf(error, sizeof(error), "unknown input event type at index %u", index);
+            break;
+        }
+    }
+
+    uint64_t elapsed_ns = 0;
+    if (error[0] == '\0') {
+        uint64_t started_ns = monotonic_ns();
+        for (uint32_t index = 0; index < count; index++) {
+            InputEvent *event = &events[index];
+            Bool accepted;
+            if (event->kind == EVENT_MOTION) {
+                accepted = XTestFakeMotionEvent(
+                    input_display,
+                    input_screen,
+                    event->x,
+                    event->y,
+                    CurrentTime
+                );
+            } else if (event->kind == EVENT_BUTTON) {
+                accepted = XTestFakeButtonEvent(
+                    input_display,
+                    event->code,
+                    event->down,
+                    CurrentTime
+                );
+            } else {
+                accepted = XTestFakeKeyEvent(
+                    input_display,
+                    event->keycode,
+                    event->down,
+                    CurrentTime
+                );
+            }
+            if (!accepted) {
+                snprintf(error, sizeof(error), "XTest rejected input event at index %u", index);
+                break;
+            }
+        }
+        XSync(input_display, False);
+        elapsed_ns = monotonic_ns() - started_ns;
+    }
+    pthread_mutex_unlock(&input_mutex);
+    free(events);
+
+    if (error[0] != '\0') {
+        return send_error(fd, opcode, STATUS_INPUT, error);
+    }
+    uint8_t response[8];
+    write_u64(response, elapsed_ns);
+    return send_response(fd, opcode, STATUS_OK, response, sizeof(response));
+}
+
+static void *client_thread_main(void *argument) {
+    int fd = (int)(intptr_t)argument;
+    int authenticated = 0;
+
+    for (;;) {
+        uint8_t header[REQUEST_HEADER_SIZE];
+        int read_result = read_full(fd, header, sizeof(header));
+        if (read_result <= 0) {
+            break;
+        }
+        uint32_t magic = read_u32(header);
+        uint16_t version = read_u16(header + 4);
+        uint16_t opcode = read_u16(header + 6);
+        uint32_t length = read_u32(header + 8);
+        if (magic != GA_MAGIC || version != GA_VERSION || length > MAX_REQUEST_SIZE) {
+            send_error(fd, opcode, STATUS_PROTOCOL, "invalid fast-I/O request header");
+            break;
+        }
+
+        uint8_t *payload = NULL;
+        if (length > 0) {
+            payload = malloc(length);
+            if (payload == NULL || read_full(fd, payload, length) <= 0) {
+                free(payload);
+                break;
+            }
+        }
+
+        int result;
+        if (!authenticated) {
+            if (opcode != OP_HELLO) {
+                result = send_error(fd, opcode, STATUS_AUTH, "hello is required first");
+            } else {
+                result = handle_hello(fd, opcode, payload, length);
+                if (result == 0) {
+                    authenticated = 1;
+                }
+            }
+        } else if (opcode == OP_PING && length == 0) {
+            result = send_response(fd, opcode, STATUS_OK, NULL, 0);
+        } else if (opcode == OP_SCREENSHOT) {
+            result = handle_screenshot(fd, opcode, payload, length);
+        } else if (opcode == OP_ACTION) {
+            result = handle_action(fd, opcode, payload, length);
+        } else {
+            result = send_error(fd, opcode, STATUS_PROTOCOL, "unknown fast-I/O operation");
+        }
+        free(payload);
+        if (result < 0) {
+            break;
+        }
+    }
+
+    close(fd);
+    return NULL;
+}
+
+static void stop_server(int signal_number) {
+    (void)signal_number;
+    running = 0;
+    int fd = listen_fd;
+    if (fd >= 0) {
+        close(fd);
+    }
+}
+
+static int parse_port(int argc, char **argv) {
+    int port = 5902;
+    for (int index = 1; index < argc; index++) {
+        if (strcmp(argv[index], "--port") == 0 && index + 1 < argc) {
+            port = atoi(argv[++index]);
+        } else {
+            fprintf(stderr, "usage: %s [--port PORT]\n", argv[0]);
+            return -1;
+        }
+    }
+    if (port < 1 || port > 65535) {
+        fprintf(stderr, "invalid port: %d\n", port);
+        return -1;
+    }
+    return port;
+}
+
+int main(int argc, char **argv) {
+    int port = parse_port(argc, argv);
+    if (port < 0) {
+        return 2;
+    }
+    auth_token = getenv("GA_FAST_IO_TOKEN");
+    if (auth_token == NULL || auth_token[0] == '\0') {
+        fprintf(stderr, "GA_FAST_IO_TOKEN is required\n");
+        return 2;
+    }
+
+    signal(SIGPIPE, SIG_IGN);
+    struct sigaction action;
+    memset(&action, 0, sizeof(action));
+    action.sa_handler = stop_server;
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGTERM, &action, NULL);
+    sigaction(SIGINT, &action, NULL);
+
+    if (!XInitThreads()) {
+        fprintf(stderr, "XInitThreads failed\n");
+        return 1;
+    }
+    pthread_t capture_thread;
+    if (pthread_create(&capture_thread, NULL, capture_thread_main, NULL) != 0) {
+        fprintf(stderr, "could not start the X11 capture thread\n");
+        return 1;
+    }
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    while (frame_cache.ready == 0) {
+        pthread_cond_wait(&frame_cache.changed, &frame_cache.mutex);
+    }
+    if (frame_cache.ready < 0) {
+        fprintf(stderr, "fast screenshot initialization failed: %s\n", frame_cache.error);
+        pthread_mutex_unlock(&frame_cache.mutex);
+        return 1;
+    }
+    pthread_mutex_unlock(&frame_cache.mutex);
+
+    input_display = XOpenDisplay(NULL);
+    if (input_display == NULL) {
+        fprintf(stderr, "could not open the X11 display for input\n");
+        return 1;
+    }
+    int event_base, error_base, major, minor;
+    if (!XTestQueryExtension(input_display, &event_base, &error_base, &major, &minor)) {
+        fprintf(stderr, "the X11 display does not support XTest\n");
+        return 1;
+    }
+    input_screen = DefaultScreen(input_display);
+
+    listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (listen_fd < 0) {
+        perror("socket");
+        return 1;
+    }
+    int enabled = 1;
+    setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled));
+    struct sockaddr_in address;
+    memset(&address, 0, sizeof(address));
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_ANY);
+    address.sin_port = htons((uint16_t)port);
+    if (bind(listen_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+        perror("bind");
+        return 1;
+    }
+    if (listen(listen_fd, 16) < 0) {
+        perror("listen");
+        return 1;
+    }
+
+    while (running) {
+        int client_fd = accept(listen_fd, NULL, NULL);
+        if (client_fd < 0) {
+            if (errno == EINTR || !running) {
+                continue;
+            }
+            perror("accept");
+            break;
+        }
+        setsockopt(client_fd, IPPROTO_TCP, TCP_NODELAY, &enabled, sizeof(enabled));
+        setsockopt(client_fd, SOL_SOCKET, SO_KEEPALIVE, &enabled, sizeof(enabled));
+        pthread_t client_thread;
+        if (pthread_create(
+            &client_thread,
+            NULL,
+            client_thread_main,
+            (void *)(intptr_t)client_fd
+        ) != 0) {
+            close(client_fd);
+            continue;
+        }
+        pthread_detach(client_thread);
+    }
+
+    pthread_mutex_lock(&frame_cache.mutex);
+    frame_cache.stopping = 1;
+    pthread_cond_broadcast(&frame_cache.changed);
+    pthread_mutex_unlock(&frame_cache.mutex);
+    XCloseDisplay(input_display);
+    return 0;
+}

--- a/src/gym_anything/runtime/runners/modal_native_assets/ga-fast-io.service
+++ b/src/gym_anything/runtime/runners/modal_native_assets/ga-fast-io.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Gym Anything native X11 fast I/O
+Requires=ga-vnc.service
+After=ga-vnc.service
+
+[Service]
+Type=simple
+User=ga
+Environment=DISPLAY=:1
+Environment=XAUTHORITY=/home/ga/.Xauthority
+EnvironmentFile=/etc/gym-anything/fast-io.env
+ExecStart=/usr/local/bin/ga-modal-native-fast-io --port 5902
+Restart=on-failure
+RestartSec=1
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/src/gym_anything/runtime/runners/modal_native_fast_io.py
+++ b/src/gym_anything/runtime/runners/modal_native_fast_io.py
@@ -1,0 +1,529 @@
+"""Low-latency client for the Modal Native X11 input and display service."""
+
+from __future__ import annotations
+
+import mmap
+import os
+import socket
+import ssl
+import struct
+import threading
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .vnc_utils import char_needs_shift, char_to_keysym, key_to_keysym
+
+
+FAST_IO_PORT = 5902
+
+_MAGIC = 0x47414649
+_VERSION = 1
+
+_OP_HELLO = 1
+_OP_PING = 2
+_OP_SCREENSHOT = 3
+_OP_ACTION = 4
+
+_REQUEST_HEADER = struct.Struct("!IHHI")
+_RESPONSE_HEADER = struct.Struct("!IHHII")
+_HELLO_RESPONSE = struct.Struct("!IIII")
+_SCREENSHOT_REQUEST = struct.Struct("!Q")
+_SCREENSHOT_META = struct.Struct("!IIIIQQQ")
+_ACTION_RESPONSE = struct.Struct("!Q")
+_EVENT = struct.Struct("!BBHIii")
+
+_EVENT_MOTION = 1
+_EVENT_BUTTON = 2
+_EVENT_KEY = 3
+_FRAME_DATA_FOLLOWS = 1
+
+_MAX_EVENTS = 4096
+_MAX_RESPONSE_BYTES = 256 * 1024 * 1024
+_DRAG_STEPS = 8
+
+_LOCAL_FRAME_PATH = "/dev/shm/gym-anything-modal-native-fast-io"
+_LOCAL_HEADER_SIZE = 4096
+_LOCAL_PREFIX = struct.Struct("=4sIIIII")
+_LOCAL_U64 = struct.Struct("=Q")
+_LOCAL_SLOT_META = struct.Struct("=QQQQ")
+_LOCAL_FRAME_MAGIC = b"GAFS"
+_LOCAL_FRAME_SLOTS = 3
+
+
+class ModalNativeFastIOError(RuntimeError):
+    """The native fast-I/O service rejected or could not complete a request."""
+
+
+WireEvent = Tuple[int, int, int, int, int]
+
+
+def _key_keysym(key: str) -> int:
+    normalized = key.strip()
+    lower = normalized.lower()
+    if lower.startswith("f") and lower[1:].isdigit():
+        number = int(lower[1:])
+        if 1 <= number <= 35:
+            return 0xFFBD + number
+    return key_to_keysym(normalized)
+
+
+def _motion(x: int, y: int) -> WireEvent:
+    return (_EVENT_MOTION, 0, 0, int(x), int(y))
+
+
+def _button(button: int, down: bool) -> WireEvent:
+    return (_EVENT_BUTTON, int(down), int(button), 0, 0)
+
+
+def _key(keysym: int, down: bool) -> WireEvent:
+    return (_EVENT_KEY, int(down), int(keysym), 0, 0)
+
+
+def _tap_key(keysym: int) -> List[WireEvent]:
+    return [_key(keysym, True), _key(keysym, False)]
+
+
+def _text_events(text: str) -> List[WireEvent]:
+    events: List[WireEvent] = []
+    for char in text:
+        if char in {"\n", "\r"}:
+            events.extend(_tap_key(_key_keysym("Return")))
+            continue
+        if char == "\t":
+            events.extend(_tap_key(_key_keysym("Tab")))
+            continue
+        if char == "\b":
+            events.extend(_tap_key(_key_keysym("BackSpace")))
+            continue
+
+        shifted, base_key = char_needs_shift(char)
+        if shifted:
+            events.append(_key(_key_keysym("Shift_L"), True))
+        events.extend(_tap_key(char_to_keysym(base_key)))
+        if shifted:
+            events.append(_key(_key_keysym("Shift_L"), False))
+    return events
+
+
+def events_for_action(action: Dict[str, Any]) -> List[WireEvent]:
+    """Translate the public action shape into one atomic XTest event batch."""
+    events: List[WireEvent] = []
+
+    def click(x: int, y: int, button: int, count: int = 1) -> None:
+        events.append(_motion(x, y))
+        for _ in range(count):
+            events.extend((_button(button, True), _button(button, False)))
+
+    def drag(points: Iterable[Iterable[int]], button: int) -> None:
+        start, end = points
+        x1, y1 = (int(value) for value in start)
+        x2, y2 = (int(value) for value in end)
+        events.extend((_motion(x1, y1), _button(button, True)))
+        for step in range(1, _DRAG_STEPS + 1):
+            x = int(x1 + (x2 - x1) * step / _DRAG_STEPS)
+            y = int(y1 + (y2 - y1) * step / _DRAG_STEPS)
+            events.append(_motion(x, y))
+        events.append(_button(button, False))
+
+    mouse = action.get("mouse") or {}
+    if "left_click" in mouse:
+        click(*map(int, mouse["left_click"]), button=1)
+    if "right_click" in mouse:
+        click(*map(int, mouse["right_click"]), button=3)
+    if "middle_click" in mouse:
+        click(*map(int, mouse["middle_click"]), button=2)
+    if "double_click" in mouse:
+        click(*map(int, mouse["double_click"]), button=1, count=2)
+    if "triple_click" in mouse:
+        click(*map(int, mouse["triple_click"]), button=1, count=3)
+    if "left_click_drag" in mouse:
+        drag(mouse["left_click_drag"], button=1)
+    if "right_click_drag" in mouse:
+        drag(mouse["right_click_drag"], button=3)
+    if "move" in mouse:
+        events.append(_motion(*map(int, mouse["move"])))
+
+    buttons = mouse.get("buttons") or {}
+    for name, button, down in (
+        ("left_down", 1, True),
+        ("left_up", 1, False),
+        ("middle_down", 2, True),
+        ("middle_up", 2, False),
+        ("right_down", 3, True),
+        ("right_up", 3, False),
+    ):
+        if buttons.get(name):
+            events.append(_button(button, down))
+
+    if "scroll" in mouse:
+        amount = int(mouse["scroll"])
+        wheel_button = 5 if amount > 0 else 4
+        for _ in range(abs(amount)):
+            events.extend((_button(wheel_button, True), _button(wheel_button, False)))
+
+    keyboard = action.get("keyboard") or {}
+    if "text" in keyboard:
+        events.extend(_text_events(str(keyboard["text"])))
+    if "keys" in keyboard:
+        keys = keyboard["keys"]
+        key_list = [keys] if isinstance(keys, str) else list(keys)
+        keysyms = [_key_keysym(str(value)) for value in key_list]
+        events.extend(_key(keysym, True) for keysym in keysyms)
+        events.extend(_key(keysym, False) for keysym in reversed(keysyms))
+    if "keys_down" in keyboard:
+        keys = keyboard["keys_down"]
+        for value in ([keys] if isinstance(keys, str) else keys):
+            events.append(_key(_key_keysym(str(value)), True))
+    if "keys_up" in keyboard:
+        keys = keyboard["keys_up"]
+        for value in ([keys] if isinstance(keys, str) else keys):
+            events.append(_key(_key_keysym(str(value)), False))
+
+    if len(events) > _MAX_EVENTS:
+        raise ValueError(
+            f"Modal Native fast input action expands to {len(events)} events; "
+            f"the maximum is {_MAX_EVENTS}"
+        )
+    return events
+
+
+def _encode_events(events: List[WireEvent]) -> bytes:
+    payload = bytearray(struct.pack("!I", len(events)))
+    for kind, down, code, x, y in events:
+        payload.extend(_EVENT.pack(kind, down, 0, code, x, y))
+    return bytes(payload)
+
+
+class ModalNativeFastIOClient:
+    """Persistent authenticated client for the in-VM native X11 service."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        token: str,
+        resolution: Tuple[int, int],
+        *,
+        timeout: float = 30.0,
+        use_tls: bool = True,
+    ):
+        self.host = host
+        self.port = int(port)
+        self.token = token
+        self.resolution = tuple(int(value) for value in resolution)
+        self.timeout = float(timeout)
+        self.use_tls = bool(use_tls)
+        self._socket: Optional[socket.socket] = None
+        self._lock = threading.RLock()
+        self._frame_id = 0
+        self._cached_image = None
+        self._local_frame_map: Optional[mmap.mmap] = None
+        self._last_local_ping_ns = 0
+        self.last_frame_captured_ns = 0
+        self.last_server_capture_ns = 0
+        self.last_server_action_ns = 0
+
+    def connect(self, retry_count: int = 10, retry_delay: float = 1.0) -> None:
+        last_error: Optional[BaseException] = None
+        for attempt in range(retry_count):
+            try:
+                with self._lock:
+                    self._connect_locked()
+                return
+            except BaseException as exc:
+                last_error = exc
+                self.close()
+                if attempt < retry_count - 1:
+                    time.sleep(retry_delay)
+        raise ModalNativeFastIOError(
+            f"Could not connect to Modal Native fast I/O at {self.host}:{self.port}: "
+            f"{last_error}"
+        ) from last_error
+
+    def _connect_locked(self) -> None:
+        self._close_locked()
+        raw_socket = socket.create_connection((self.host, self.port), self.timeout)
+        raw_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        raw_socket.settimeout(self.timeout)
+        try:
+            if self.use_tls:
+                context = ssl.create_default_context()
+                connection = context.wrap_socket(raw_socket, server_hostname=self.host)
+            else:
+                connection = raw_socket
+        except BaseException:
+            raw_socket.close()
+            raise
+        self._socket = connection
+        try:
+            payload = self._request_locked(_OP_HELLO, self.token.encode("utf-8"))
+            if len(payload) != _HELLO_RESPONSE.size:
+                raise ModalNativeFastIOError("Malformed fast-I/O hello response")
+            width, height, channels, capabilities = _HELLO_RESPONSE.unpack(payload)
+            if (width, height) != self.resolution:
+                raise ModalNativeFastIOError(
+                    "Modal Native fast-I/O resolution mismatch: "
+                    f"expected {self.resolution}, got {(width, height)}"
+                )
+            if channels != 3 or not capabilities & 1:
+                raise ModalNativeFastIOError(
+                    "Modal Native fast-I/O service lacks RGB/XShm/XTest support"
+                )
+            self._frame_id = 0
+            self._cached_image = None
+            self._open_local_frames_locked()
+        except BaseException:
+            self._close_locked()
+            raise
+
+    def close(self) -> None:
+        with self._lock:
+            self._close_locked()
+
+    def _close_locked(self) -> None:
+        self._cached_image = None
+        local_frame_map, self._local_frame_map = self._local_frame_map, None
+        if local_frame_map is not None:
+            try:
+                local_frame_map.close()
+            except OSError:
+                pass
+        connection, self._socket = self._socket, None
+        if connection is not None:
+            try:
+                connection.close()
+            except OSError:
+                pass
+
+    def _open_local_frames_locked(self) -> None:
+        if self.host not in {"127.0.0.1", "localhost", "::1"}:
+            return
+        path = os.environ.get(
+            "GYM_ANYTHING_MODAL_NATIVE_FAST_IO_SHM", _LOCAL_FRAME_PATH
+        )
+        try:
+            fd = os.open(path, os.O_RDONLY)
+        except OSError:
+            return
+        try:
+            local_frame_map = mmap.mmap(fd, 0, access=mmap.ACCESS_READ)
+        finally:
+            os.close(fd)
+        try:
+            magic, version, width, height, stride, slots = _LOCAL_PREFIX.unpack_from(
+                local_frame_map, 0
+            )
+            required_size = _LOCAL_HEADER_SIZE + stride * height * slots
+            if (
+                magic != _LOCAL_FRAME_MAGIC
+                or version != _VERSION
+                or (width, height) != self.resolution
+                or stride != width * 3
+                or slots != _LOCAL_FRAME_SLOTS
+                or len(local_frame_map) < required_size
+            ):
+                raise ModalNativeFastIOError(
+                    "Modal Native local fast-frame metadata is incompatible"
+                )
+        except BaseException:
+            local_frame_map.close()
+            raise
+        self._local_frame_map = local_frame_map
+        self._last_local_ping_ns = time.monotonic_ns()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._socket is not None
+
+    def _recv_exact_locked(self, size: int) -> bytearray:
+        if self._socket is None:
+            raise ConnectionError("Modal Native fast-I/O socket is not connected")
+        data = bytearray(size)
+        view = memoryview(data)
+        offset = 0
+        while offset < size:
+            received = self._socket.recv_into(view[offset:])
+            if received == 0:
+                raise ConnectionError("Modal Native fast-I/O service closed the connection")
+            offset += received
+        return data
+
+    def _request_locked(self, opcode: int, payload: bytes = b"") -> bytearray:
+        if self._socket is None:
+            raise ConnectionError("Modal Native fast-I/O socket is not connected")
+        self._socket.sendall(
+            _REQUEST_HEADER.pack(_MAGIC, _VERSION, opcode, len(payload)) + payload
+        )
+        header = self._recv_exact_locked(_RESPONSE_HEADER.size)
+        magic, version, response_opcode, status, length = _RESPONSE_HEADER.unpack(header)
+        if magic != _MAGIC or version != _VERSION or response_opcode != opcode:
+            raise ModalNativeFastIOError("Malformed fast-I/O response header")
+        if length > _MAX_RESPONSE_BYTES:
+            raise ModalNativeFastIOError(
+                f"Fast-I/O response is unreasonably large: {length} bytes"
+            )
+        response = self._recv_exact_locked(length)
+        if status:
+            message = bytes(response).decode("utf-8", errors="replace")
+            raise ModalNativeFastIOError(message or f"Fast-I/O service error {status}")
+        return response
+
+    def _request(self, opcode: int, payload: bytes = b"", *, retry_safe: bool) -> bytearray:
+        with self._lock:
+            if self._socket is None:
+                self._connect_locked()
+            try:
+                return self._request_locked(opcode, payload)
+            except (OSError, ConnectionError, ssl.SSLError) as exc:
+                self._close_locked()
+                if retry_safe:
+                    self._connect_locked()
+                    return self._request_locked(opcode, payload)
+                raise ModalNativeFastIOError(
+                    "Modal Native fast input connection failed after dispatch; "
+                    "the action was not retried because its execution state is unknown"
+                ) from exc
+
+    def ping(self) -> None:
+        self._request(_OP_PING, retry_safe=True)
+
+    def inject_action(self, action: Dict[str, Any]) -> None:
+        events = events_for_action(action)
+        if not events:
+            return
+        response = self._request(
+            _OP_ACTION, _encode_events(events), retry_safe=False
+        )
+        if len(response) != _ACTION_RESPONSE.size:
+            raise ModalNativeFastIOError("Malformed fast-input acknowledgement")
+        (self.last_server_action_ns,) = _ACTION_RESPONSE.unpack(response)
+
+    def capture_image(self):
+        from PIL import Image
+
+        with self._lock:
+            if self._local_frame_map is not None:
+                now_ns = time.monotonic_ns()
+                if now_ns - self._last_local_ping_ns >= 1_000_000_000:
+                    self._request(_OP_PING, retry_safe=True)
+                    self._last_local_ping_ns = now_ns
+                if self._local_frame_map is not None:
+                    return self._capture_local_image_locked(Image)
+            return self._capture_remote_image_locked(Image)
+
+    def _capture_remote_image_locked(self, image_class):
+        response = self._request(
+            _OP_SCREENSHOT,
+            _SCREENSHOT_REQUEST.pack(self._frame_id),
+            retry_safe=True,
+        )
+        if len(response) < _SCREENSHOT_META.size:
+            raise ModalNativeFastIOError("Malformed fast-I/O screenshot response")
+        (
+            width,
+            height,
+            stride,
+            flags,
+            frame_id,
+            captured_ns,
+            capture_elapsed_ns,
+        ) = _SCREENSHOT_META.unpack(response[: _SCREENSHOT_META.size])
+        if (width, height) != self.resolution or stride != width * 3:
+            raise ModalNativeFastIOError(
+                "Modal Native fast-I/O frame geometry changed unexpectedly: "
+                f"{width}x{height}, stride={stride}"
+            )
+
+        if flags & _FRAME_DATA_FOLLOWS:
+            expected = _SCREENSHOT_META.size + stride * height
+            if len(response) != expected:
+                raise ModalNativeFastIOError(
+                    f"Malformed fast-I/O frame: expected {expected} bytes, "
+                    f"received {len(response)}"
+                )
+            frame_view = memoryview(response)[_SCREENSHOT_META.size :]
+            try:
+                self._cached_image = image_class.frombytes(
+                    "RGB",
+                    (width, height),
+                    frame_view,
+                    "raw",
+                    "RGB",
+                    stride,
+                    1,
+                )
+            finally:
+                frame_view.release()
+        elif len(response) != _SCREENSHOT_META.size:
+            raise ModalNativeFastIOError("Unexpected data in unchanged screenshot response")
+
+        missing_changed_frame = frame_id != self._frame_id and not (
+            flags & _FRAME_DATA_FOLLOWS
+        )
+        if self._cached_image is None or missing_changed_frame:
+            raise ModalNativeFastIOError("Fast-I/O service omitted required frame data")
+
+        self._frame_id = frame_id
+        self.last_frame_captured_ns = captured_ns
+        self.last_server_capture_ns = capture_elapsed_ns
+        return self._cached_image.copy()
+
+    def _capture_local_image_locked(self, image_class):
+        local_frame_map = self._local_frame_map
+        if local_frame_map is None:
+            raise ModalNativeFastIOError("Local fast-frame mapping is unavailable")
+        width, height = self.resolution
+        stride = width * 3
+        frame_size = stride * height
+        for _ in range(50):
+            (slot_index,) = _LOCAL_U64.unpack_from(local_frame_map, 24)
+            if slot_index >= _LOCAL_FRAME_SLOTS:
+                time.sleep(0)
+                continue
+            metadata_offset = 32 + slot_index * _LOCAL_SLOT_META.size
+            sequence, frame_id, captured_ns, capture_elapsed_ns = (
+                _LOCAL_SLOT_META.unpack_from(local_frame_map, metadata_offset)
+            )
+            if sequence & 1:
+                time.sleep(0)
+                continue
+            if frame_id == self._frame_id and self._cached_image is not None:
+                self.last_frame_captured_ns = captured_ns
+                self.last_server_capture_ns = capture_elapsed_ns
+                return self._cached_image.copy()
+            frame_offset = _LOCAL_HEADER_SIZE + slot_index * frame_size
+            frame_view = memoryview(local_frame_map)[
+                frame_offset : frame_offset + frame_size
+            ]
+            try:
+                image = image_class.frombytes(
+                    "RGB",
+                    (width, height),
+                    frame_view,
+                    "raw",
+                    "RGB",
+                    stride,
+                    1,
+                )
+            finally:
+                frame_view.release()
+            (sequence_after,) = _LOCAL_U64.unpack_from(
+                local_frame_map, metadata_offset
+            )
+            if sequence == sequence_after and not sequence_after & 1:
+                self._frame_id = frame_id
+                self.last_frame_captured_ns = captured_ns
+                self.last_server_capture_ns = capture_elapsed_ns
+                self._cached_image = image
+                return image.copy()
+        raise ModalNativeFastIOError(
+            "Could not read a stable Modal Native shared-memory frame"
+        )
+
+
+__all__ = [
+    "FAST_IO_PORT",
+    "ModalNativeFastIOClient",
+    "ModalNativeFastIOError",
+    "events_for_action",
+]

--- a/src/gym_anything/runtime/runners/modal_native_image.py
+++ b/src/gym_anything/runtime/runners/modal_native_image.py
@@ -35,6 +35,10 @@ _APT_PACKAGES = [
     "imagemagick",
     "inkscape",
     "libgimp2.0-dev",
+    "libx11-dev",
+    "libxdamage-dev",
+    "libxext-dev",
+    "libxtst-dev",
     "locales",
     "net-tools",
     "novnc",
@@ -146,6 +150,16 @@ def build_modal_native_image(modal):
             copy=True,
         )
         .add_local_file(
+            assets / "ga-fast-io.service",
+            "/etc/systemd/system/ga-fast-io.service",
+            copy=True,
+        )
+        .add_local_file(
+            assets / "fast_io_server.c",
+            "/tmp/ga-modal-native-fast-io.c",
+            copy=True,
+        )
+        .add_local_file(
             assets / "ga-snap-transitions.service",
             "/etc/systemd/system/ga-snap-transitions.service",
             copy=True,
@@ -153,6 +167,9 @@ def build_modal_native_image(modal):
         .run_commands(
             "apt-get purge -y gnome-initial-setup || true; "
             "apt-get remove -y update-notifier || true",
+            "gcc -O3 -flto -fopenmp -DNDEBUG -std=c11 -Wall -Wextra -Werror -pthread "
+            "/tmp/ga-modal-native-fast-io.c -o /usr/local/bin/ga-modal-native-fast-io "
+            "-lX11 -lXext -lXdamage -lXtst; rm /tmp/ga-modal-native-fast-io.c",
             "chmod 0755 /usr/local/sbin/ga-modal-native-bootstrap "
             "/usr/local/sbin/ga-nsenter /usr/local/sbin/ga-systemd-init "
             "/usr/local/sbin/ga-snap-transitions /usr/local/sbin/ga-snap-mounts "

--- a/tests/test_modal_native_runner.py
+++ b/tests/test_modal_native_runner.py
@@ -13,6 +13,12 @@ from gym_anything.specs import EnvSpec
 from gym_anything.env import GymAnythingEnv
 from gym_anything.config.validators import validate_env_spec
 from gym_anything.runtime.runners.modal_native import ModalNativeRunner, VNC_PORT
+from gym_anything.runtime.runners import modal_native_fast_io as fast_io
+from gym_anything.runtime.runners.modal_native_fast_io import (
+    FAST_IO_PORT,
+    ModalNativeFastIOClient,
+    events_for_action,
+)
 from gym_anything.runtime.runners.modal_native_image import MODAL_NATIVE_IMAGE_FINGERPRINT
 from gym_anything.runtime.runners.vnc_utils import VNCConnection
 
@@ -108,6 +114,10 @@ class _FakeTunnel:
     tcp_socket = ("modal-vnc.example", 43210)
 
 
+class _FakeFastIOTunnel:
+    tls_socket = ("modal-fast-io.example", 443)
+
+
 class _FakeSandbox:
     create_calls = []
 
@@ -127,7 +137,10 @@ class _FakeSandbox:
         return sandbox
 
     def tunnels(self):
-        return {VNC_PORT: _FakeTunnel()}
+        return {
+            VNC_PORT: _FakeTunnel(),
+            FAST_IO_PORT: _FakeFastIOTunnel(),
+        }
 
     def exec(self, *args, **kwargs):
         self.exec_calls.append((args, kwargs))
@@ -284,6 +297,40 @@ class ModalNativeRunnerTests(unittest.TestCase):
         runner.stop()
         self.assertTrue(sandbox.terminated)
 
+    def test_fast_start_exposes_tls_service_and_connects_native_client(self):
+        runner = ModalNativeRunner(_spec())
+        runner.set_fast_io(True)
+        client = mock.Mock()
+        with mock.patch(
+            "gym_anything.runtime.runners.modal_native.build_modal_native_image",
+            return_value=_FakeImage(),
+        ), mock.patch.object(runner, "_wait_for_desktop"), mock.patch.object(
+            runner, "_setup_mounts"
+        ), mock.patch.object(runner, "_connect_vnc"), mock.patch(
+            "gym_anything.runtime.runners.modal_native.ModalNativeFastIOClient",
+            return_value=client,
+        ) as client_class:
+            runner.start()
+
+        _, kwargs, sandbox = _FakeSandbox.create_calls[-1]
+        self.assertEqual(kwargs["cpu"], (4.0, 4.0))
+        self.assertEqual(kwargs["encrypted_ports"], [FAST_IO_PORT])
+        self.assertEqual(
+            kwargs["env"]["GYM_ANYTHING_FAST_IO_TOKEN"], runner._fast_io_token
+        )
+        client_class.assert_called_once_with(
+            "modal-fast-io.example",
+            443,
+            runner._fast_io_token,
+            (1280, 720),
+            timeout=30.0,
+        )
+        client.connect.assert_called_once_with(retry_count=30, retry_delay=1.0)
+        service_command = sandbox.exec_calls[-1][0][-1]
+        self.assertEqual(service_command, "systemctl restart ga-fast-io.service")
+        runner.stop()
+        client.close.assert_called_once()
+
     def test_start_cleans_up_sandbox_when_interrupted(self):
         runner = ModalNativeRunner(_spec())
         with mock.patch(
@@ -359,6 +406,19 @@ class ModalNativeRunnerTests(unittest.TestCase):
         self.assertNotIn(
             "firefox", transition + mounts + wrapper + service + image_builder
         )
+        self.assertIn("ga-fast-io.service", image_builder)
+        self.assertIn("libxdamage-dev", image_builder)
+        fast_service = (assets / "ga-fast-io.service").read_text(encoding="utf-8")
+        fast_server = (assets / "fast_io_server.c").read_text(encoding="utf-8")
+        self.assertIn("Requires=ga-vnc.service", fast_service)
+        self.assertIn("XShmGetImage", fast_server)
+        self.assertIn("XDamageCreate", fast_server)
+        self.assertNotIn("XCheckTypedEvent", fast_server)
+        self.assertIn("XTestFakeKeyEvent", fast_server)
+        self.assertIn("convert_xrgb_ssse3", fast_server)
+        self.assertIn("#pragma omp parallel", fast_server)
+        self.assertIn("LOCAL_FRAME_PATH", fast_server)
+        self.assertIn("frame_cache.next_slot", fast_server)
 
     def test_exec_enters_systemd_namespace_and_merges_environment(self):
         runner = ModalNativeRunner(_spec())
@@ -418,6 +478,24 @@ class ModalNativeRunnerTests(unittest.TestCase):
         connection.type_text.assert_called_once_with("Hi")
         connection.send_key_combo.assert_called_once_with(["ctrl", "a"])
         self.assertEqual(connection.send_key.call_count, 2)
+
+    def test_fast_action_and_screenshot_bypass_vnc(self):
+        from PIL import Image
+
+        runner = ModalNativeRunner(_spec())
+        runner.set_fast_io(True)
+        client = mock.Mock()
+        client.capture_image.return_value = Image.new("RGB", (1280, 720), "red")
+        runner._fast_io_client = client
+        action = {"keyboard": {"text": "native"}}
+        with mock.patch.object(
+            runner, "_vnc_connection", side_effect=AssertionError("VNC hot path")
+        ):
+            runner.inject_action(action)
+            image = runner.capture_screenshot_image()
+        client.inject_action.assert_called_once_with(action)
+        self.assertEqual(image.mode, "RGB")
+        self.assertEqual(image.getpixel((0, 0)), (255, 0, 0))
 
     def test_mount_copy_replaces_target_and_keeps_environment_source_unchanged(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -520,6 +598,11 @@ class _FragmentedSocket:
             return value[:size]
         return value
 
+    def recv_into(self, buffer):
+        value = self.recv(len(buffer))
+        buffer[: len(value)] = value
+        return len(value)
+
     def sendall(self, data):
         self.sent.append(data)
 
@@ -531,6 +614,138 @@ class _FragmentedSocket:
 
     def close(self):
         self.closed = True
+
+
+class ModalNativeFastIOTests(unittest.TestCase):
+    @staticmethod
+    def _response(opcode, payload=b"", status=0):
+        return (
+            fast_io._RESPONSE_HEADER.pack(
+                fast_io._MAGIC,
+                fast_io._VERSION,
+                opcode,
+                status,
+                len(payload),
+            )
+            + payload
+        )
+
+    def test_action_translation_batches_mouse_text_and_hotkey(self):
+        events = events_for_action(
+            {
+                "mouse": {"left_click": [10, 20], "scroll": 1},
+                "keyboard": {"text": "A", "keys": ["ctrl", "a"]},
+            }
+        )
+        self.assertEqual(
+            events,
+            [
+                (1, 0, 0, 10, 20),
+                (2, 1, 1, 0, 0),
+                (2, 0, 1, 0, 0),
+                (2, 1, 5, 0, 0),
+                (2, 0, 5, 0, 0),
+                (3, 1, 0xFFE1, 0, 0),
+                (3, 1, ord("a"), 0, 0),
+                (3, 0, ord("a"), 0, 0),
+                (3, 0, 0xFFE1, 0, 0),
+                (3, 1, 0xFFE3, 0, 0),
+                (3, 1, ord("a"), 0, 0),
+                (3, 0, ord("a"), 0, 0),
+                (3, 0, 0xFFE3, 0, 0),
+            ],
+        )
+        f24_events = events_for_action({"keyboard": {"keys": "f24"}})
+        self.assertEqual([event[2] for event in f24_events], [0xFFD5, 0xFFD5])
+
+    def test_screenshot_protocol_reuses_unchanged_cached_frame(self):
+        pixels = bytes((255, 0, 0, 0, 255, 0))
+        first_metadata = fast_io._SCREENSHOT_META.pack(
+            2, 1, 6, 1, 7, 123456, 142_000
+        )
+        second_metadata = fast_io._SCREENSHOT_META.pack(
+            2, 1, 6, 0, 7, 123456, 142_000
+        )
+        first_response = self._response(
+            fast_io._OP_SCREENSHOT, first_metadata + pixels
+        )
+        second_response = self._response(fast_io._OP_SCREENSHOT, second_metadata)
+        sock = _FragmentedSocket(
+            [
+                first_response[:3],
+                first_response[3:19],
+                first_response[19:],
+                second_response,
+            ]
+        )
+        client = ModalNativeFastIOClient(
+            "host", 443, "token", (2, 1), use_tls=False
+        )
+        client._socket = sock
+
+        first = client.capture_image()
+        first.putpixel((0, 0), (0, 0, 0))
+        second = client.capture_image()
+
+        self.assertEqual(first.mode, "RGB")
+        self.assertEqual(first.getpixel((1, 0)), (0, 255, 0))
+        self.assertEqual(second.getpixel((0, 0)), (255, 0, 0))
+        self.assertEqual(second.getpixel((1, 0)), (0, 255, 0))
+        self.assertEqual(client.last_frame_captured_ns, 123456)
+        self.assertEqual(client.last_server_capture_ns, 142_000)
+        requested_frame_ids = [
+            fast_io._SCREENSHOT_REQUEST.unpack(message[-8:])[0]
+            for message in sock.sent
+        ]
+        self.assertEqual(requested_frame_ids, [0, 7])
+
+    def test_action_acknowledgement_reports_in_vm_elapsed_time(self):
+        payload = fast_io._ACTION_RESPONSE.pack(16_000)
+        sock = _FragmentedSocket(
+            [self._response(fast_io._OP_ACTION, payload)]
+        )
+        client = ModalNativeFastIOClient(
+            "host", 443, "token", (2, 1), use_tls=False
+        )
+        client._socket = sock
+        client.inject_action({"keyboard": {"text": "x"}})
+        self.assertEqual(client.last_server_action_ns, 16_000)
+        _, _, opcode, request_size = fast_io._REQUEST_HEADER.unpack(
+            sock.sent[0][: fast_io._REQUEST_HEADER.size]
+        )
+        self.assertEqual(opcode, fast_io._OP_ACTION)
+        self.assertGreater(request_size, 4)
+
+    def test_local_shared_frame_returns_stable_rgb_image_without_socket_transfer(self):
+        frame_size = 2 * 1 * 3
+        mapping_size = fast_io._LOCAL_HEADER_SIZE + frame_size * 3
+        with tempfile.TemporaryFile() as backing:
+            backing.truncate(mapping_size)
+            import mmap
+
+            mapping = mmap.mmap(backing.fileno(), mapping_size)
+            fast_io._LOCAL_PREFIX.pack_into(
+                mapping, 0, b"GAFS", fast_io._VERSION, 2, 1, 6, 3
+            )
+            fast_io._LOCAL_U64.pack_into(mapping, 24, 0)
+            fast_io._LOCAL_SLOT_META.pack_into(
+                mapping, 32, 2, 9, 123_000, 140_000
+            )
+            mapping[fast_io._LOCAL_HEADER_SIZE : fast_io._LOCAL_HEADER_SIZE + 6] = (
+                bytes((1, 2, 3, 4, 5, 6))
+            )
+            client = ModalNativeFastIOClient(
+                "127.0.0.1", 5902, "token", (2, 1), use_tls=False
+            )
+            client._local_frame_map = mapping
+            client._last_local_ping_ns = fast_io.time.monotonic_ns()
+            image = client.capture_image()
+            image.putpixel((0, 0), (0, 0, 0))
+            second = client.capture_image()
+            self.assertEqual(list(second.getdata()), [(1, 2, 3), (4, 5, 6)])
+            self.assertEqual(client._frame_id, 9)
+            self.assertEqual(client.last_server_capture_ns, 140_000)
+            client.close()
 
 
 class VNCTransportTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a native Modal VM fast-I/O service using XDamage, MIT-SHM, round-robin shared-memory frame buffers, parallel SSSE3 RGB conversion, and XTest input batches
- use a persistent token-authenticated Modal TLS tunnel remotely and a seqlock-protected shared-memory path for colocated Python clients
- preserve the existing VNC path when fast I/O is disabled and leave environment code unchanged
- request at least four vCPUs in fast mode so RGB conversion remains within the measured latency target

## Validation

- `PYTHONPATH=src python -m pytest tests -q` — 268 passed, 22 skipped
- `PYTHONPATH=src python -m pytest tests/test_modal_native_runner.py -q` — 26 passed
- Ruff and `git diff --check` pass
- production Modal image compiles the native daemon with `-Wall -Wextra -Werror`
- wheel contents verified to include the Python client, C daemon, and systemd service
- live-tested Moodle and Google Earth loading, RGB screenshots, keyboard input, mouse movement, clicks, drags, and scrolling

### In-VM latency at 1920x1080

| Operation | p50 | p95 | max |
| --- | ---: | ---: | ---: |
| Changed screenshot to isolated RGB PIL object | 1.98 ms | 2.28 ms | 2.65 ms |
| Cached screenshot | 0.55 ms | 0.57 ms | 5.22 ms |
| Input round trip | 0.044 ms | 0.050 ms | 0.60 ms |
| Native server capture | 1.28 ms | 1.50 ms | 1.53 ms |

Remote calls retain the same native backend but additionally pay Modal tunnel and WAN transfer time.
