### PR TITLE
Add deferred observations and frame sequences

### DIFF
--- a/agents/agents/gemini_computer_use.py
+++ b/agents/agents/gemini_computer_use.py
@@ -51,8 +51,15 @@ SYSTEM_INSTRUCTION = (
     "You are operating a single desktop application that is ALREADY OPEN and fills "
     "the screen. Interact directly with what is on screen using clicks, typing, and "
     "keyboard shortcuts via the computer tool. Look carefully at each screenshot "
-    "before acting. When the task is fully complete, stop calling the tool and "
-    "reply with a short confirmation instead."
+    "before acting. Solve only from screenshots and visible controls in the task "
+    "webpage. Do not use code, scripts, automation, Developer Tools, the console, "
+    "debugger, inspector, network panel, source or DOM inspection, page-state "
+    "inspection, a terminal, shell, Python, address-bar or URL changes, query edits, "
+    "reload, navigation, browser extensions, external applications, or hidden-state "
+    "access. Do not switch to unrelated tabs. A tab opened by a visible task control "
+    "is allowed only when it is part of the task and only through its visible controls. "
+    "When the task is fully complete, stop calling the tool and reply with a short "
+    "confirmation instead."
 )
 
 # Gemini key names -> env (X11 keysym-ish) names used by the env layer.
@@ -80,6 +87,18 @@ _MAX_CONSECUTIVE_UNSUPPORTED = 3
 
 def _uses_legacy_actions(model: str) -> bool:
     return model.startswith(_LEGACY_MODEL_PREFIXES)
+
+
+def _observation_frame_paths(obs) -> list[Path]:
+    paths = []
+    for frame in obs.get("frames") or []:
+        value = frame.get("path") if isinstance(frame, dict) else frame
+        if value:
+            paths.append(Path(value))
+    if paths:
+        return paths
+    screen_path = (obs.get("screen") or {}).get("path")
+    return [Path(screen_path)] if screen_path else []
 
 
 class GeminiComputerUseAgent(BaseAgent):
@@ -113,7 +132,22 @@ class GeminiComputerUseAgent(BaseAgent):
         if excluded is None:
             excluded = _LEGACY_BROWSER_FUNCTIONS if self.legacy_actions else _NEW_BROWSER_FUNCTIONS
 
-        self.client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
+        self.request_timeout_seconds = max(1, int(self.agent_args.get("request_timeout_seconds", 120)))
+        self.request_attempts = max(1, int(self.agent_args.get("request_attempts", 3)))
+        self.client = genai.Client(
+            api_key=os.getenv("GEMINI_API_KEY"),
+            http_options=types.HttpOptions(
+                timeout=self.request_timeout_seconds * 1000,
+                retryOptions=types.HttpRetryOptions(
+                    attempts=self.request_attempts,
+                    initialDelay=1.0,
+                    maxDelay=8.0,
+                    expBase=2.0,
+                    jitter=0.2,
+                    httpStatusCodes=[408, 429, *range(500, 600)],
+                ),
+            ),
+        )
         self.tool = types.Tool(
             computer_use=types.ComputerUse(
                 environment=self.environment,
@@ -171,8 +205,14 @@ class GeminiComputerUseAgent(BaseAgent):
 
     def save_observation(self, obs):
         try:
-            Image.open(obs["screen"]["path"]).save(
-                f"{self.save_folder_custom}/observation_{self.step_idx}.png")
+            paths = _observation_frame_paths(obs)
+            if not paths:
+                return
+            Image.open(paths[-1]).save(f"{self.save_folder_custom}/observation_{self.step_idx}.png")
+            if len(paths) > 1:
+                for frame_index, path in enumerate(paths):
+                    Image.open(path).save(
+                        f"{self.save_folder_custom}/observation_{self.step_idx}_frame_{frame_index}.png")
         except Exception as exc:
             print(f"[gemini-cu] save_observation failed: {exc}")
 
@@ -185,13 +225,17 @@ class GeminiComputerUseAgent(BaseAgent):
     def step(self, obs, action_outputs):
         self.save_observation(obs)
         self.step_idx += 1
-        shot = Path(obs["screen"]["path"]).read_bytes()
+        frame_paths = _observation_frame_paths(obs)
+        if not frame_paths:
+            raise ValueError("Gemini Computer Use requires a screen path or frame sequence")
+        shots = [path.read_bytes() for path in frame_paths]
 
         if not self.contents:
-            self.contents.append(types.Content(role="user", parts=[
-                types.Part(text=self.task_description),
-                types.Part.from_bytes(data=shot, mime_type="image/png"),
-            ]))
+            parts = [types.Part(text=self.task_description)]
+            if len(shots) > 1:
+                parts.append(types.Part(text="Screenshots below are ordered from earliest to latest."))
+            parts.extend(types.Part.from_bytes(data=shot, mime_type="image/png") for shot in shots)
+            self.contents.append(types.Content(role="user", parts=parts))
         else:
             resp = {}
             if self._is_browser_env:
@@ -202,7 +246,7 @@ class GeminiComputerUseAgent(BaseAgent):
                 resp["error"] = self.pending_error
             if self.pending_safety:
                 resp["safety_acknowledgement"] = "true"
-            fr = self._function_response(self.pending_name, self.pending_id, resp, shot)
+            fr = self._function_response(self.pending_name, self.pending_id, resp, shots)
             self.contents.append(types.Content(role="user", parts=[types.Part(function_response=fr)]))
             self.pending_safety = False
             self.pending_error = None
@@ -436,20 +480,32 @@ class GeminiComputerUseAgent(BaseAgent):
                 out.append(_KEYMAP.get(k.lower(), k))
         return out
 
-    def _function_response(self, name, fid, resp, shot):
-        blob = types.FunctionResponseBlob(mime_type="image/png", data=shot)
-        part = types.FunctionResponsePart(inline_data=blob)
+    def _function_response(self, name, fid, resp, shots):
+        parts = [
+            types.FunctionResponsePart(
+                inline_data=types.FunctionResponseBlob(mime_type="image/png", data=shot)
+            )
+            for shot in shots
+        ]
         try:
-            return types.FunctionResponse(id=fid, name=name or "computer", response=resp, parts=[part])
+            return types.FunctionResponse(id=fid, name=name or "computer", response=resp, parts=parts)
         except Exception:
-            return types.FunctionResponse(name=name or "computer", response=resp, parts=[part])
+            return types.FunctionResponse(name=name or "computer", response=resp, parts=parts)
 
     # ---- persistence ------------------------------------------------------
     def _dump_transcript(self):
         try:
             with open(f"{self.save_folder_custom}/trajectory.json", "w") as fh:
-                json.dump({"model": self.model, "task": getattr(self, "task_description", ""),
-                           "steps": self.transcript}, fh, indent=2)
+                json.dump({
+                    "model": self.model,
+                    "task": getattr(self, "task_description", ""),
+                    "request_policy": {
+                        "timeout_seconds": getattr(self, "request_timeout_seconds", None),
+                        "total_attempts": getattr(self, "request_attempts", None),
+                        "retry_statuses": [408, 429, "5xx"],
+                    },
+                    "steps": self.transcript,
+                }, fh, indent=2)
         except Exception as exc:
             print(f"[gemini-cu] trajectory dump failed: {exc}")
 

--- a/docs/content/docs/agents/index.mdx
+++ b/docs/content/docs/agents/index.mdx
@@ -86,6 +86,12 @@ The `actions` list can contain normal environment actions such as mouse and keyb
 
 Those control actions are handled by the environment layer, not by the evaluation loop.
 
+`GeminiComputerUseAgent` accepts either the normal `obs["screen"]["path"]` or
+a chronological `obs["frames"]` list. When several frames are present, every
+frame is sent in order in the initial request and in later computer function
+responses. Its request deadline and total retry attempts can be set with
+`request_timeout_seconds` and `request_attempts` in `agent_args`.
+
 ## Autonomous Agents (External CLI Harnesses)
 
 Some agents are not step-based. `ClaudeCodeAgent` and `CodexCliAgent` wrap

--- a/docs/content/docs/core/environments.mdx
+++ b/docs/content/docs/core/environments.mdx
@@ -92,6 +92,21 @@ If you want to finish a task and run its checker, call:
 obs, reward, done, info = env.step([], mark_done=True)
 ```
 
+An integration that controls its own observation schedule can apply actions
+without the normal post-action delay or screenshot:
+
+```python
+obs, reward, done, info = env.step(
+    actions,
+    capture_observation=False,
+    settle_after_actions=False,
+)
+```
+
+The returned observation is `{}` in this case. Call `capture_observation()` or
+provide the integration's own observation before the next model turn. The same
+keyword arguments are supported by `RemoteGymEnv.step(...)`.
+
 ## When To Use `capture_observation()`
 
 <Callout type="info">

--- a/src/gym_anything/env.py
+++ b/src/gym_anything/env.py
@@ -673,7 +673,21 @@ class GymAnythingEnv:
         # First observation (capture initial screen/audio as frame_00000)
         return self._capture_observation()
 
-    def step(self, actions: List[Dict[str, Any]], wait_between_actions: float = 0.2, mark_done: bool = False) -> Tuple[Dict[str, Any], float, bool, Dict[str, Any]]:
+    def step(
+        self,
+        actions: List[Dict[str, Any]],
+        wait_between_actions: float = 0.2,
+        mark_done: bool = False,
+        *,
+        capture_observation: bool = True,
+        settle_after_actions: bool = True,
+    ) -> Tuple[Dict[str, Any], float, bool, Dict[str, Any]]:
+        """Apply actions and optionally defer settling and observation capture.
+
+        Integrations that control the environment clock can set both keyword
+        flags to ``False``, then capture their own observation window. Existing
+        callers retain the original settle-and-capture behavior.
+        """
         # Multi-agent: accept mapping role->action, else annotate turn-based role
         if isinstance(actions, dict):
             actions = [actions]
@@ -710,15 +724,15 @@ class GymAnythingEnv:
                 injected_actions += 1
             if wait_between_actions and action_num < len(actions) - 1:
                 time.sleep(wait_between_actions)
-        if injected_actions:
+        if injected_actions and settle_after_actions:
             settle_seconds = self._post_action_settle_seconds()
             if settle_seconds > 0:
                 time.sleep(settle_seconds)
         # For synchronous envs, wait for the step cycle unless fast I/O asked for immediate observation.
-        cycle_seconds = self._step_cycle_settle_seconds(injected_actions)
+        cycle_seconds = self._step_cycle_settle_seconds(injected_actions) if settle_after_actions else 0.0
         if cycle_seconds > 0:
             time.sleep(cycle_seconds)
-        obs: Dict[str, Any] = self._capture_observation()
+        obs: Dict[str, Any] = self._capture_observation() if capture_observation else {}
 
         # Log step
         if self._traj_log:

--- a/src/gym_anything/remote/client.py
+++ b/src/gym_anything/remote/client.py
@@ -369,14 +369,23 @@ class RemoteGymEnv:
 
         return obs
     
-    def step(self, actions: List[Dict[str, Any]], wait_between_actions: float = 0.2,
-             mark_done: bool = False) -> Tuple[Dict[str, Any], float, bool, Dict[str, Any]]:
+    def step(
+        self,
+        actions: List[Dict[str, Any]],
+        wait_between_actions: float = 0.2,
+        mark_done: bool = False,
+        *,
+        capture_observation: bool = True,
+        settle_after_actions: bool = True,
+    ) -> Tuple[Dict[str, Any], float, bool, Dict[str, Any]]:
         """Execute actions in the environment.
         
         Args:
             actions: List of action dictionaries
             wait_between_actions: Wait time between actions in seconds
             mark_done: Whether to mark episode as done
+            capture_observation: Whether to capture the normal post-action observation
+            settle_after_actions: Whether to apply the normal post-action delays
             
         Returns:
             Tuple of (observation, reward, done, info)
@@ -387,7 +396,9 @@ class RemoteGymEnv:
             json={
                 "actions": actions,
                 "wait_between_actions": wait_between_actions,
-                "mark_done": mark_done
+                "mark_done": mark_done,
+                "capture_observation": capture_observation,
+                "settle_after_actions": settle_after_actions,
             }
         )
         

--- a/src/gym_anything/remote/worker.py
+++ b/src/gym_anything/remote/worker.py
@@ -920,11 +920,15 @@ def step_environment(env_id: str):
         actions = data.get("actions", [])
         wait_between_actions = data.get("wait_between_actions", 0.2)
         mark_done = data.get("mark_done", False)
+        capture_observation = data.get("capture_observation", True)
+        settle_after_actions = data.get("settle_after_actions", True)
 
         obs, reward, done, info = env.step(
             actions=actions,
             wait_between_actions=wait_between_actions,
-            mark_done=mark_done
+            mark_done=mark_done,
+            capture_observation=capture_observation,
+            settle_after_actions=settle_after_actions,
         )
 
         if metrics_collector:

--- a/tests/test_env_runtime_behaviors.py
+++ b/tests/test_env_runtime_behaviors.py
@@ -272,6 +272,32 @@ class RuntimeBehaviorTests(unittest.TestCase):
             finally:
                 env.close()
 
+    def test_step_can_defer_settling_and_observation_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = _FakeRunner()
+            with mock.patch.object(GymAnythingEnv, "_select_runner", return_value=runner):
+                env = GymAnythingEnv(_make_env_spec(tmp), None)
+
+            try:
+                env.reset(seed=1)
+                with mock.patch.object(env, "_capture_observation") as capture_mock, \
+                     mock.patch("gym_anything.env.time.sleep") as sleep_mock:
+                    obs, reward, done, info = env.step(
+                        [{"mouse": {"move": [1, 2]}}],
+                        capture_observation=False,
+                        settle_after_actions=False,
+                    )
+
+                self.assertEqual(obs, {})
+                self.assertEqual(reward, 0.0)
+                self.assertFalse(done)
+                self.assertEqual(info["action_result"]["output"], "Executed the action")
+                self.assertEqual(runner.injected_actions, [{"mouse": {"move": [1, 2]}}])
+                capture_mock.assert_not_called()
+                sleep_mock.assert_not_called()
+            finally:
+                env.close()
+
     def test_close_runs_post_task_hook_for_unfinished_episode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runner = _FakeRunner()

--- a/tests/test_gemini_computer_use_translation.py
+++ b/tests/test_gemini_computer_use_translation.py
@@ -9,9 +9,11 @@ No API access needed: we build the agent without __init__ and call
 _translate directly.
 """
 import unittest
+from pathlib import Path
 
 from agents.agents.gemini_computer_use import (
     GeminiComputerUseAgent,
+    _observation_frame_paths,
     _uses_legacy_actions,
 )
 
@@ -30,6 +32,32 @@ class ModelFamilyTests(unittest.TestCase):
         self.assertTrue(_uses_legacy_actions("gemini-3-flash-preview"))
         self.assertTrue(_uses_legacy_actions("gemini-2.5-computer-use-preview-10-2025"))
         self.assertFalse(_uses_legacy_actions("gemini-3.5-flash"))
+
+
+class ObservationSequenceTests(unittest.TestCase):
+    def test_frames_take_precedence_and_keep_chronological_order(self):
+        obs = {
+            "screen": {"path": "latest.png"},
+            "frames": [
+                {"path": "first.png", "offset_ms": 0},
+                {"path": "second.png", "offset_ms": 100},
+            ],
+        }
+        self.assertEqual(
+            _observation_frame_paths(obs),
+            [Path("first.png"), Path("second.png")],
+        )
+
+    def test_screen_remains_the_single_frame_fallback(self):
+        self.assertEqual(
+            _observation_frame_paths({"screen": {"path": "latest.png"}}),
+            [Path("latest.png")],
+        )
+
+    def test_function_response_contains_every_frame(self):
+        agent = _bare_agent()
+        response = agent._function_response("computer", "call-1", {}, [b"one", b"two"])
+        self.assertEqual([part.inline_data.data for part in response.parts], [b"one", b"two"])
 
 
 class LegacyVocabularyTests(unittest.TestCase):

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -58,6 +58,11 @@ class PublicApiContractTests(unittest.TestCase):
     def test_env_exposes_public_capture_screenshot_image(self) -> None:
         self.assertTrue(callable(getattr(GymAnythingEnv, "capture_screenshot_image", None)))
 
+    def test_step_exposes_deferred_capture_controls(self) -> None:
+        params = inspect.signature(GymAnythingEnv.step).parameters
+        self.assertIn("capture_observation", params)
+        self.assertIn("settle_after_actions", params)
+
     def test_env_exposes_public_episode_dir_property(self) -> None:
         self.assertIsInstance(getattr(GymAnythingEnv, "episode_dir", None), property)
 
@@ -84,6 +89,11 @@ class PublicApiContractTests(unittest.TestCase):
 
     def test_remote_exposes_public_capture_observation(self) -> None:
         self.assertTrue(callable(getattr(RemoteGymEnv, "capture_observation", None)))
+
+    def test_remote_step_exposes_deferred_capture_controls(self) -> None:
+        params = inspect.signature(RemoteGymEnv.step).parameters
+        self.assertIn("capture_observation", params)
+        self.assertIn("settle_after_actions", params)
 
     def test_remote_exposes_public_episode_dir_property(self) -> None:
         self.assertIsInstance(getattr(RemoteGymEnv, "episode_dir", None), property)

--- a/tests/test_remote_client.py
+++ b/tests/test_remote_client.py
@@ -72,6 +72,35 @@ class RemoteClientResetPolicyTests(unittest.TestCase):
         self.assertEqual(env.max_steps, 3)
         self.assertEqual(env.timeout_sec, 120)
 
+    def test_step_sends_deferred_capture_controls(self) -> None:
+        env = self._make_env()
+        response = mock.Mock()
+        response.json.return_value = {
+            "observation": {},
+            "reward": 0.0,
+            "done": False,
+            "info": {"step": 0},
+        }
+
+        with mock.patch.object(env, "_request", return_value=response) as request_mock:
+            result = env.step(
+                [{"mouse": {"move": [1, 2]}}],
+                capture_observation=False,
+                settle_after_actions=False,
+            )
+
+        self.assertEqual(result[0], {})
+        self.assertEqual(
+            request_mock.call_args.kwargs["json"],
+            {
+                "actions": [{"mouse": {"move": [1, 2]}}],
+                "wait_between_actions": 0.2,
+                "mark_done": False,
+                "capture_observation": False,
+                "settle_after_actions": False,
+            },
+        )
+
     def test_create_remote_env_sends_verifier_overrides(self) -> None:
         response = mock.Mock()
         response.json.return_value = {"env_id": "env-123"}


### PR DESCRIPTION
## Summary
- let integrations apply actions without the normal settle or screenshot while preserving existing `step` behavior
- support chronological multi-frame observations in the Gemini computer-use adapter
- record a finite Gemini request deadline and one retry policy
- expose the deferred step controls through the remote client and worker

## Tests
- `PYTHONPATH="$PWD/src:$PWD" python -m pytest tests -q`
- 275 passed, 22 skipped