### PR TITLE
Make pre-task setup failure opt-in

### DIFF
--- a/docs/content/docs/reference/specs.mdx
+++ b/docs/content/docs/reference/specs.mdx
@@ -137,6 +137,7 @@ Current task hook fields are:
 - `pre_task`
 - `post_task`
 - `pre_task_timeout`
+- `fail_on_error` (default `false`; abort reset when `pre_task` fails)
 
 ### Success modes
 

--- a/src/gym_anything/env.py
+++ b/src/gym_anything/env.py
@@ -599,6 +599,7 @@ class GymAnythingEnv:
                 if self._reporter:
                     self._reporter.stage_start("pre_task_hook")
                 logger.info("Running pre_task hook")
+                fail_on_error = self.task_spec.hooks.fail_on_error
                 try:
                     hook_cmd = self.task_spec.hooks.pre_task
                     # Android uses sh instead of bash, and different paths
@@ -619,12 +620,13 @@ class GymAnythingEnv:
                             use_pty=False,
                             timeout=hook_timeout,
                         )
-                    _require_hook_success(
-                        self._runner,
-                        "pre_task hook",
-                        return_code,
-                        "/tmp/task_pre_task.log",
-                    )
+                    if fail_on_error:
+                        _require_hook_success(
+                            self._runner,
+                            "pre_task hook",
+                            return_code,
+                            "/tmp/task_pre_task.log",
+                        )
                     self._capture_observation()
                     if self._reporter:
                         self._reporter.stage_done("pre_task_hook")
@@ -632,7 +634,8 @@ class GymAnythingEnv:
                     logger.warning("pre_task hook failed: %s", e)
                     if self._reporter:
                         self._reporter.stage_fail("pre_task_hook", str(e))
-                    raise
+                    if fail_on_error:
+                        raise
 
             # === TASK INIT SCRIPT ===
             if self.task_spec and self.task_spec.init.init_script:

--- a/src/gym_anything/specs.py
+++ b/src/gym_anything/specs.py
@@ -465,6 +465,7 @@ class TaskHooks:
     pre_task: Optional[str] = None
     post_task: Optional[str] = None
     pre_task_timeout: int = 600  # Timeout in seconds for pre_task hook (default 10 min)
+    fail_on_error: bool = False
 
 
 @dataclass

--- a/tests/test_env_runtime_behaviors.py
+++ b/tests/test_env_runtime_behaviors.py
@@ -28,6 +28,7 @@ class _FakeRunner:
         self.injected_actions = []
         self.fast_io = False
         self.image_capture_calls = 0
+        self.exec_returncode = 0
 
     def start(self, seed=None) -> None:
         self.start_calls += 1
@@ -59,7 +60,7 @@ class _FakeRunner:
 
     def exec(self, command: str, **kwargs) -> int:
         self.exec_commands.append(command)
-        return 0
+        return self.exec_returncode
 
     def exec_capture(self, command: str) -> str:
         return ""
@@ -134,6 +135,42 @@ def _make_env_spec(output_dir: str, *, runner: str | None = None, recording: boo
 
 
 class RuntimeBehaviorTests(unittest.TestCase):
+    def test_pre_task_failure_is_permissive_by_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = _FakeRunner()
+            runner.exec_returncode = 17
+            task_spec = TaskSpec.from_dict(
+                {"id": "demo-task", "hooks": {"pre_task": "false"}}
+            )
+            with mock.patch.object(GymAnythingEnv, "_select_runner", return_value=runner):
+                env = GymAnythingEnv(_make_env_spec(tmp), task_spec)
+
+            try:
+                env.reset(seed=1)
+            finally:
+                env.close()
+
+    def test_pre_task_failure_can_be_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = _FakeRunner()
+            runner.exec_returncode = 17
+            task_spec = TaskSpec.from_dict(
+                {
+                    "id": "demo-task",
+                    "hooks": {"pre_task": "false", "fail_on_error": True},
+                }
+            )
+            with mock.patch.object(GymAnythingEnv, "_select_runner", return_value=runner):
+                env = GymAnythingEnv(_make_env_spec(tmp), task_spec)
+
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError, "pre_task hook exited with code 17"
+                ):
+                    env.reset(seed=1)
+            finally:
+                env.close()
+
     def test_step_handles_wait_control_action_inside_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             runner = _FakeRunner()
@@ -290,7 +327,7 @@ class RuntimeBehaviorTests(unittest.TestCase):
             env.close()
 
             self.assertIn(
-                "bash -lc 'echo exported' > /home/ga/task_post_task.log 2>&1",
+                "bash -lc 'echo exported' > /tmp/task_post_task.log 2>&1",
                 runner.exec_commands,
             )
             self.assertEqual(runner.stop_calls, 1)


### PR DESCRIPTION
## Summary
- restore canonical permissive pre-task hook behavior by default
- add an explicit `hooks.fail_on_error` opt-in for benchmarks such as OSWorld
- document and test both policies

## Verification
- `PYTHONPATH=src python -m pytest tests -q`
- 272 passed, 22 skipped